### PR TITLE
Kotlin backports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 /dist
 yarn.lock
 testers/dist
+README-unity.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### 🔧 Build & CI
+
+- Add automatic changelog generation from git commits
+- Add git tagging for published versions
+- Add conventional commits support for better categorization
+
+---
+
+*Previous versions (1.0.1 - 1.0.20) were published before changelog automation was implemented. Future versions will have detailed changelogs generated from commit messages.*
+
+*To see changes in previous versions, you can view the git history:*
+```bash
+git log v1.0.19..v1.0.20 --oneline  # Example for version 1.0.20
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Contributing to AbxrLib for WebXR
+
+## Commit Message Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) to automatically generate changelogs and determine semantic version bumps.
+
+### Commit Message Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **perf**: A code change that improves performance
+- **test**: Adding missing tests or correcting existing tests
+- **build**: Changes that affect the build system or external dependencies
+- **ci**: Changes to our CI configuration files and scripts
+- **chore**: Other changes that don't modify src or test files
+
+### Examples
+
+```bash
+feat: add virtual keyboard support for WebXR
+fix(auth): resolve authentication timeout issue
+docs: update README with new installation instructions
+style: format code according to prettier rules
+refactor(client): simplify connection logic
+perf: optimize rendering performance in VR mode
+test: add unit tests for authentication flow
+build: update webpack configuration
+ci: add automated testing workflow
+chore: update dependencies
+```
+
+### Scopes (Optional)
+
+Common scopes in this project:
+- `auth`: Authentication related changes
+- `client`: AbxrLibClient changes
+- `analytics`: Analytics functionality
+- `storage`: Storage utilities
+- `network`: Network layer changes
+- `ui`: User interface components
+- `vr`: VR-specific functionality
+- `webxr`: WebXR API integration
+
+## Changelog Generation
+
+The changelog is automatically generated from commit messages when publishing new versions. The script categorizes commits based on their type:
+
+- **✨ Features**: `feat` commits
+- **🐛 Bug Fixes**: `fix` commits  
+- **⚡ Performance**: `perf` commits
+- **♻️ Refactoring**: `refactor` commits
+- **📚 Documentation**: `docs` commits
+- **🔧 Build & CI**: `build`, `ci` commits
+- **🔨 Other Changes**: `chore`, `style`, `test` commits
+
+## Manual Changelog Generation
+
+You can generate a changelog manually using:
+
+```bash
+# Generate full changelog
+npm run changelog
+
+# Generate changelog for a specific version
+npm run changelog:version 1.0.21
+```
+
+## Publishing Process
+
+### Automated Publishing with Changelog
+
+Use the new automated publish script that handles the complete workflow:
+
+```bash
+./publish-with-changelog.sh
+```
+
+This script:
+1. **Checks prerequisites** (git repo, .env file, uncommitted changes)
+2. **Runs Docker build and publish** (increments patch version automatically)
+3. **Generates changelog** from git commits since last tag
+4. **Creates git tag** for the new version
+5. **Commits changelog** if changes were made
+6. **Optionally pushes** to remote repository
+
+### Manual Docker Publishing (Legacy)
+
+You can still use the Docker-only approach, but you'll need to handle git operations manually:
+
+```bash
+docker-compose -f docker-compose-publish.yml up --build
+```
+
+After Docker publish completes, manually:
+```bash
+# Get the published version
+PUBLISHED_VERSION=$(npm view abxrlib-for-webxr version)
+
+# Generate changelog
+npm run changelog:version $PUBLISHED_VERSION
+
+# Create git tag
+git tag -a "v$PUBLISHED_VERSION" -m "Release version $PUBLISHED_VERSION"
+
+# Commit and push
+git add CHANGELOG.md
+git commit -m "docs: update changelog for version $PUBLISHED_VERSION"
+git push origin main
+git push origin "v$PUBLISHED_VERSION"
+```
+
+## Git Tagging
+
+Each published version is automatically tagged in git with the format `v{version}` (e.g., `v1.0.21`). This allows the changelog generator to determine what commits belong to each release.
+
+To push tags to remote after publishing:
+```bash
+git push origin v1.0.21  # Replace with actual version
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY abxr-launch.sh ./
 RUN chmod +x abxr-launch.sh
 COPY src ./src
 COPY testers ./testers
+COPY scripts ./scripts
 
 RUN npm install
 RUN npm install process --save-dev

--- a/README-PUBLISHING.md
+++ b/README-PUBLISHING.md
@@ -1,0 +1,130 @@
+# Publishing Guide
+
+## Quick Start
+
+To publish a new version with automatic changelog generation:
+
+```bash
+./publish-with-changelog.sh
+```
+
+## Prerequisites
+
+1. **Environment file**: Create `.env` with your npm token:
+   ```bash
+   NPM_TOKEN=your_npm_access_token_here
+   ```
+
+2. **Clean git state**: Commit any pending changes before publishing
+
+3. **Docker**: Ensure Docker and Docker Compose are installed
+
+## What the Script Does
+
+### 1. Pre-flight Checks ✈️
+- Verifies you're in a git repository
+- Checks for uncommitted changes (warns if found)
+- Validates `.env` file exists
+- Shows current and next version numbers
+
+### 2. Docker Build & Publish 🐳
+- Runs `docker-compose -f docker-compose-publish.yml up --build`
+- Builds TypeScript, creates webpack bundle
+- Auto-increments patch version (e.g., 1.0.20 → 1.0.21)
+- Publishes to npm registry
+
+### 3. Git Operations 🏷️
+- Generates changelog from commits since last tag
+- Creates git tag `v1.0.21` for the new version
+- Commits changelog updates
+- Optionally pushes to remote
+
+### 4. Interactive Prompts 💬
+- Asks if you want to continue with uncommitted changes
+- Asks if you want to push to remote repository
+- Shows summary of what was accomplished
+
+## Example Output
+
+```
+🚀 Starting AbxrLib publish process...
+📦 Checking current published version...
+Current published version: 1.0.20
+Next version will be: 1.0.21
+
+🐳 Running Docker build and publish...
+[Docker build output...]
+
+✅ Successfully published version: 1.0.21
+📝 Generating changelog for version 1.0.21...
+✅ Changelog updated successfully
+📝 Committing changelog updates...
+🏷️ Creating git tag v1.0.21...
+✅ Git tag v1.0.21 created successfully
+
+🎉 Publish process completed successfully!
+
+📋 Summary:
+  • Published version: 1.0.21
+  • Git tag created: v1.0.21
+  • Changelog updated: ✅
+
+Push changes to remote now? (y/N):
+```
+
+## Manual Alternative
+
+If you prefer to handle steps manually:
+
+```bash
+# 1. Publish with Docker only
+docker-compose -f docker-compose-publish.yml up --build
+
+# 2. Get published version
+PUBLISHED_VERSION=$(npm view abxrlib-for-webxr version)
+
+# 3. Generate changelog
+npm run changelog:version $PUBLISHED_VERSION
+
+# 4. Create git tag and commit
+git add CHANGELOG.md
+git commit -m "docs: update changelog for version $PUBLISHED_VERSION"
+git tag -a "v$PUBLISHED_VERSION" -m "Release version $PUBLISHED_VERSION"
+
+# 5. Push to remote
+git push origin main
+git push origin "v$PUBLISHED_VERSION"
+```
+
+## Troubleshooting
+
+### "Not in a git repository"
+- Run the script from the project root directory
+- Ensure `.git` folder exists
+
+### "NPM_TOKEN not found"
+- Create `.env` file with your npm access token
+- Get token from https://www.npmjs.com/settings/tokens
+
+### "Docker publish failed"
+- Check Docker is running
+- Verify `.env` file has correct NPM_TOKEN
+- Check npm registry connectivity
+
+### "Changelog generation failed"
+- Ensure `scripts/generate-changelog.js` exists
+- Check Node.js is installed on host system
+- Verify git history is available
+
+## Conventional Commits
+
+For better changelog categorization, use conventional commit format:
+
+```bash
+feat: add new VR controller support
+fix(auth): resolve login timeout issue  
+docs: update API documentation
+refactor: simplify connection logic
+```
+
+See `CONTRIBUTING.md` for full conventional commit guidelines.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ npm install abxrlib-for-webxr
 
 ## Configuration
 
-### Using with ArborXR Insights Early Access
+### Using with ArborXR Insights
 
-To use the ABXRLib SDK with ArborXR Insights Early Access program:
+To use the ABXRLib SDK with ArborXR Insights:
 
-#### Get Early Access Credentials
-1. Go to the ArborXR Insights Early Access web app and log in (will require [official Early Access sign up](https://arborxr.com/insights-early-access) & onboarding process to access).
+#### Get Your Credentials
+1. Go to the ArborXR Insights web app and log in.
 2. Grab these three values from the **View Data** screen of the specific app you are configuring:
 - App ID
 - Organization ID
@@ -80,15 +80,17 @@ To use the ABXRLib SDK with ArborXR Insights Early Access program:
 
 The ABXRLib SDK now provides a simplified initialization API. The `appId` is required, while `orgId` and `authSecret` are optional and can be provided via URL parameters.
 
+> **⚠️ Security Note:** For production builds distributed to third parties, avoid compiling `orgId` and `authSecret` directly into your application code. Instead, use URL parameters or environment variables to provide these credentials at runtime. Only compile credentials directly into the build when creating custom applications for specific individual clients.
+
 ```typescript
 import { Abxr_init, Abxr } from 'abxrlib-for-webxr';
 
-// Simple initialization with all parameters
-Abxr_init('your-app-id', 'your-org-id', 'your-auth-secret');
-
-// Or use URL parameters for orgId and authSecret
+// RECOMMENDED: Use URL parameters for production builds
 // URL: https://yourdomain.com/?abxr_orgid=YOUR_ORG_ID&abxr_auth_secret=YOUR_AUTH_SECRET
 Abxr_init('your-app-id');
+
+// DEVELOPMENT ONLY: Direct initialization with all parameters
+Abxr_init('your-app-id', 'your-org-id', 'your-auth-secret');
 
 // With custom app configuration
 const appConfig = '<?xml version="1.0" encoding="utf-8" ?><configuration><appSettings><add key="REST_URL" value="https://your-server.com/v1/"/></appSettings></configuration>';
@@ -413,9 +415,13 @@ await Abxr.EventAssessmentStart('Quiz', { startTime: Date.now(), difficulty: 'me
 - `Abxr.EventLevelStart/Complete(..., meta?)`
 - `Abxr.LogDebug/Info/Warn/Error/Critical(message, meta?)`
 
-### Event Wrappers (for LMS Compatibility)
+### Analytics Event Wrappers (Essential for All Developers)
 
-The LMS Event Functions are specialized versions of the Event method, tailored for common scenarios in XR experiences. These functions help enforce consistency in event logging across different parts of the application and are crucial for powering integrations with Learning Management System (LMS) platforms. By using these standardized wrapper functions, developers ensure that key events like starting or completing levels, assessments, or interactions are recorded in a uniform format. This consistency not only simplifies data analysis but also facilitates seamless communication with external educational systems, enhancing the overall learning ecosystem.
+**These analytics event functions are essential for ALL developers, not just those integrating with LMS platforms.** They provide standardized tracking for key user interactions and learning outcomes that are crucial for understanding user behavior, measuring engagement, and optimizing XR experiences.
+
+**EventAssessmentStart and EventAssessmentComplete should be considered REQUIRED for proper usage** of the ABXRLib SDK, as they provide critical insights into user performance and completion rates.
+
+The Analytics Event Functions are specialized versions of the Event method, tailored for common scenarios in XR experiences. These functions help enforce consistency in event logging across different parts of the application and provide valuable data for analytics, user experience optimization, and business intelligence. While they also power integrations with Learning Management System (LMS) platforms, their benefits extend far beyond educational use cases.
 
 #### Assessments
 Assessments are intended to track the overall performance of a learner across multiple Objectives and Interactions. 

--- a/abxr-launch.sh
+++ b/abxr-launch.sh
@@ -195,6 +195,10 @@ if $do_publish; then
 	cd ..
 
 	echo "Package published successfully!"
+	echo "Published version: $NEW_VERSION"
+	
+	# Write version to a file that can be read by host
+	echo "$NEW_VERSION" > /tmp/published_version.txt
 
 fi
 

--- a/docker-compose-publish.yml
+++ b/docker-compose-publish.yml
@@ -10,7 +10,9 @@ services:
     env_file:
       - .env
     command: ["--publish"]
-    #volumes:
+    volumes:
+      # Mount temp directory for version exchange (optional, fallback method)
+      - /tmp:/tmp
     #  - ./build:/opt/arborxr/build
     #  - ./dist:/opt/arborxr/dist
     #  - ./abxrlib-for-webxr:/opt/arborxr/abxrlib-for-webxr

--- a/package-README.md
+++ b/package-README.md
@@ -21,12 +21,18 @@ npm install abxrlib-for-webxr
 
 ## Simple Setup
 
+> **⚠️ Security Note:** For production builds distributed to third parties, avoid compiling `orgId` and `authSecret` directly into your application code. Instead, use URL parameters or environment variables to provide these credentials at runtime. Only compile credentials directly into the build when creating custom applications for specific individual clients.
+
 The easiest way to get started is with a single function call:
 
 ```html
 <script src="node_modules/abxrlib-for-webxr/index.js"></script>
 <script>
-    // Initialize and authenticate in one call
+    // RECOMMENDED: Use URL parameters for production builds
+    // URL: https://yourdomain.com/?abxr_orgid=org456&abxr_auth_secret=secret789
+    Abxr_init('app123');
+    
+    // DEVELOPMENT ONLY: Direct initialization with all parameters
     Abxr_init('app123', 'org456', 'secret789');
     
     // Start using the library immediately
@@ -212,7 +218,11 @@ Abxr.Event('item_collected', {
 - `name` (string): The name of the event. Use snake_case for better analytics processing.
 - `meta` (object|string|null): Optional. Additional key-value pairs describing the event. Supports multiple formats: plain objects, JSON strings, URL parameter strings, or AbxrDictStrings objects.
 
-### Event Wrappers (for LMS Compatibility)
+### Analytics Event Wrappers (Essential for All Developers)
+
+**These analytics event functions are essential for ALL developers, not just those integrating with LMS platforms.** They provide standardized tracking for key user interactions and learning outcomes that are crucial for understanding user behavior, measuring engagement, and optimizing XR experiences.
+
+**EventAssessmentStart and EventAssessmentComplete should be considered REQUIRED for proper usage** of the ABXRLib SDK, as they provide critical insights into user performance and completion rates.
 
 #### Assessments
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,21 @@
 				"localStorage": "^1.0.4",
 				"stream-browserify": "^3.0.0",
 				"threads": "^1.7.0",
+				"three": "^0.160.0",
 				"util": "^0.12.5",
 				"vm-browserify": "^1.1.2"
 			},
 			"devDependencies": {
+				"@react-three/fiber": "^8.15.0",
+				"@react-three/uikit": "^0.8.0",
 				"@types/jsonwebtoken": "^9.0.6",
 				"@types/node": "^22.9.1",
+				"@types/react": "^18.2.0",
+				"@types/react-dom": "^18.2.0",
+				"@types/three": "^0.160.0",
 				"gts": "^5.3.1",
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0",
 				"ts-loader": "^9.5.2",
 				"ts-node": "^10.9.2",
 				"typescript": "^4.9.5",
@@ -34,122 +42,52 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/@alloc/quick-lru": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.24.7",
-				"picocolors": "^1.0.0"
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/highlight": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+		"node_modules/@babel/runtime": {
+			"version": "7.28.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+			"integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.24.7",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
-			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
@@ -176,25 +114,28 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			},
 			"peerDependencies": {
 				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-			"integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+			"version": "4.12.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -273,25 +214,93 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.24"
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.30",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+			"integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -309,20 +318,10 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -331,9 +330,9 @@
 			}
 		},
 		"node_modules/@jridgewell/source-map/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.30",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+			"integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -342,9 +341,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -397,10 +396,21 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@pkgr/core": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-			"integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+			"integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -408,6 +418,146 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/@pmndrs/msdfonts": {
+			"version": "0.8.21",
+			"resolved": "https://registry.npmjs.org/@pmndrs/msdfonts/-/msdfonts-0.8.21.tgz",
+			"integrity": "sha512-6SY68a5JnjTENJ0RnYuylJJPN2XTTnnhVTf7fngYr1dp4k+FOO5WHhrEWK0E44sU2KpR46GPAv6lt9U5qebhpQ==",
+			"dev": true
+		},
+		"node_modules/@pmndrs/uikit": {
+			"version": "0.8.21",
+			"resolved": "https://registry.npmjs.org/@pmndrs/uikit/-/uikit-0.8.21.tgz",
+			"integrity": "sha512-C61c2OmCKHwLNkun/ZJYadFQBswBPN19dAwyuawV02xkbHJZ9iZZlx0ywRRXrYWNYiM4Ut5TiPKJPVXIg0Z9+w==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE",
+			"dependencies": {
+				"@pmndrs/msdfonts": "^0.8.21",
+				"@preact/signals-core": "^1.5.1",
+				"inline-style-parser": "^0.2.3",
+				"node-html-parser": "^6.1.13",
+				"tw-to-css": "^0.0.12",
+				"yoga-layout": "^3.2.1"
+			},
+			"peerDependencies": {
+				"three": ">=0.160"
+			}
+		},
+		"node_modules/@preact/signals-core": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.11.0.tgz",
+			"integrity": "sha512-jglbibeWHuFRzEWVFY/TT7wB1PppJxmcSfUHcK+2J9vBRtiooMfw6tAPttojNYrrpdGViqAYCbPpmWYlMm+eMQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
+		"node_modules/@react-three/fiber": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+			"integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.17.8",
+				"@types/react-reconciler": "^0.26.7",
+				"@types/webxr": "*",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"its-fine": "^1.0.6",
+				"react-reconciler": "^0.27.0",
+				"react-use-measure": "^2.1.7",
+				"scheduler": "^0.21.0",
+				"suspend-react": "^0.1.3",
+				"zustand": "^3.7.1"
+			},
+			"peerDependencies": {
+				"expo": ">=43.0",
+				"expo-asset": ">=8.4",
+				"expo-file-system": ">=11.0",
+				"expo-gl": ">=11.0",
+				"react": ">=18 <19",
+				"react-dom": ">=18 <19",
+				"react-native": ">=0.64",
+				"three": ">=0.133"
+			},
+			"peerDependenciesMeta": {
+				"expo": {
+					"optional": true
+				},
+				"expo-asset": {
+					"optional": true
+				},
+				"expo-file-system": {
+					"optional": true
+				},
+				"expo-gl": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"react-native": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@react-three/uikit": {
+			"version": "0.8.21",
+			"resolved": "https://registry.npmjs.org/@react-three/uikit/-/uikit-0.8.21.tgz",
+			"integrity": "sha512-auV2MVY/NiseQ3dAa5VcsE4KbLfzARnlfEZGDw668r8SO7rgvVDfANmEyVvr0NyVT8rxK+KnNujF5xhxQCQaXQ==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE",
+			"dependencies": {
+				"@pmndrs/uikit": "^0.8.21",
+				"@preact/signals-core": "^1.5.1",
+				"chalk": "^5.3.0",
+				"commander": "^12.0.0",
+				"ora": "^8.0.1",
+				"prettier": "^3.2.5",
+				"prompts": "^2.4.2",
+				"suspend-react": "^0.1.3",
+				"zod": "^3.22.4",
+				"zustand": "^4.5.2"
+			},
+			"bin": {
+				"uikit": "dist/cli/index.js"
+			},
+			"peerDependencies": {
+				"@react-three/fiber": ">=8",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@react-three/uikit/node_modules/zustand": {
+			"version": "4.5.7",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+			"integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"use-sync-external-store": "^1.2.2"
+			},
+			"engines": {
+				"node": ">=12.7.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8",
+				"immer": ">=9.0.6",
+				"react": ">=16.8"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"immer": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@tsconfig/node10": {
@@ -461,9 +611,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -475,12 +625,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/jsonwebtoken": {
-			"version": "9.0.6",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
-			"integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+			"version": "9.0.10",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+			"integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@types/ms": "*",
 				"@types/node": "*"
 			}
 		},
@@ -491,14 +642,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
-			"version": "22.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
-			"integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
+			"version": "22.17.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
+			"integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.19.8"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -508,10 +666,75 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/react": {
+			"version": "18.3.23",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/react-reconciler": {
+			"version": "0.26.7",
+			"resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+			"integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/react": "*"
+			}
+		},
 		"node_modules/@types/semver": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+			"integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/stats.js": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+			"integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/three": {
+			"version": "0.160.0",
+			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.160.0.tgz",
+			"integrity": "sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/stats.js": "*",
+				"@types/webxr": "*",
+				"fflate": "~0.6.10",
+				"meshoptimizer": "~0.18.1"
+			}
+		},
+		"node_modules/@types/webxr": {
+			"version": "0.5.22",
+			"resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+			"integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -712,9 +935,9 @@
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -941,9 +1164,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/acorn": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -951,6 +1174,19 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-import-phases": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+			"integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"peerDependencies": {
+				"acorn": "^8.14.0"
 			}
 		},
 		"node_modules/acorn-jsx": {
@@ -1090,6 +1326,27 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/arg": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1128,6 +1385,7 @@
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -1135,14 +1393,16 @@
 			}
 		},
 		"node_modules/asn1.js/node_modules/bn.js": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-			"integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"license": "MIT"
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"license": "MIT",
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
 			},
@@ -1177,17 +1437,39 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT"
+		},
+		"node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
+			"integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+			"license": "MIT"
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1211,12 +1493,14 @@
 		"node_modules/brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+			"license": "MIT"
 		},
 		"node_modules/browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"license": "MIT",
 			"dependencies": {
 				"buffer-xor": "^1.0.3",
 				"cipher-base": "^1.0.0",
@@ -1230,6 +1514,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+			"license": "MIT",
 			"dependencies": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -1240,6 +1525,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -1251,6 +1537,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
 			"integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^5.2.1",
 				"randombytes": "^2.1.0",
@@ -1264,6 +1551,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
 			"integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+			"license": "ISC",
 			"dependencies": {
 				"bn.js": "^5.2.1",
 				"browserify-rsa": "^4.1.0",
@@ -1281,9 +1569,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"version": "4.25.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+			"integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
 			"dev": true,
 			"funding": [
 				{
@@ -1301,10 +1589,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001688",
-				"electron-to-chromium": "^1.5.73",
+				"caniuse-lite": "^1.0.30001733",
+				"electron-to-chromium": "^1.5.199",
 				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.1"
+				"update-browserslist-db": "^1.1.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -1331,6 +1619,7 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
@@ -1352,7 +1641,8 @@
 		"node_modules/buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+			"license": "MIT"
 		},
 		"node_modules/builtins": {
 			"version": "5.1.0",
@@ -1368,6 +1658,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
 			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
 				"es-define-property": "^1.0.0",
@@ -1385,6 +1676,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2"
@@ -1394,12 +1686,13 @@
 			}
 		},
 		"node_modules/call-bound": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-			"integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"get-intrinsic": "^1.2.6"
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -1427,6 +1720,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase-css": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/camelcase-keys": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
@@ -1446,9 +1749,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001700",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-			"integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+			"version": "1.0.30001734",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+			"integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
 			"dev": true,
 			"funding": [
 				{
@@ -1467,17 +1770,13 @@
 			"license": "CC-BY-4.0"
 		},
 		"node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
+			"integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
@@ -1489,6 +1788,44 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.4",
@@ -1504,6 +1841,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
 			"integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.4",
 				"safe-buffer": "^5.2.1"
@@ -1523,6 +1861,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cli-width": {
@@ -1578,11 +1929,14 @@
 			"license": "MIT"
 		},
 		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -1594,26 +1948,30 @@
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"license": "MIT"
 		},
 		"node_modules/create-ecdh": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
 			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.5.3"
 			}
 		},
 		"node_modules/create-ecdh/node_modules/bn.js": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-			"integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"license": "MIT"
 		},
 		"node_modules/create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
@@ -1626,6 +1984,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -1661,6 +2020,7 @@
 			"version": "3.12.1",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
 			"integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+			"license": "MIT",
 			"dependencies": {
 				"browserify-cipher": "^1.0.1",
 				"browserify-sign": "^4.2.3",
@@ -1670,7 +2030,7 @@
 				"diffie-hellman": "^5.0.3",
 				"hash-base": "~3.0.4",
 				"inherits": "^2.0.4",
-				"pbkdf2": "^3.1.3",
+				"pbkdf2": "^3.1.2",
 				"public-encrypt": "^4.0.3",
 				"randombytes": "^2.1.0",
 				"randomfill": "^1.0.4"
@@ -1682,13 +2042,63 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/css-select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cssesc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/csstype": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/debug": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
 			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -1747,6 +2157,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -1763,10 +2174,18 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
 			"integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
 			}
+		},
+		"node_modules/didyoumean": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/diff": {
 			"version": "4.0.2",
@@ -1782,6 +2201,7 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
@@ -1789,9 +2209,10 @@
 			}
 		},
 		"node_modules/diffie-hellman/node_modules/bn.js": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-			"integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"license": "MIT"
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -1806,6 +2227,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/dlv": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1819,10 +2247,70 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
 				"es-errors": "^1.3.0",
@@ -1831,6 +2319,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -1842,9 +2337,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.102",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
-			"integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
+			"version": "1.5.200",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
+			"integrity": "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -1852,6 +2347,7 @@
 			"version": "6.6.1",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
 			"integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.11.9",
 				"brorand": "^1.1.0",
@@ -1863,9 +2359,10 @@
 			}
 		},
 		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-			"integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"license": "MIT"
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -1875,9 +2372,9 @@
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-			"integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+			"version": "5.18.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+			"integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1886,6 +2383,19 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/envinfo": {
@@ -1915,6 +2425,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -1923,14 +2434,15 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1938,6 +2450,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
 			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
 			},
@@ -1972,6 +2485,7 @@
 			"version": "8.57.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
 			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2196,6 +2710,23 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -2221,6 +2752,19 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/eslint/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/esm": {
@@ -2331,6 +2875,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"license": "MIT",
 			"dependencies": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
@@ -2359,6 +2904,13 @@
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/external-editor": {
 			"version": "3.1.0",
@@ -2390,9 +2942,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2400,7 +2952,7 @@
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.4"
+				"micromatch": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=8.6.0"
@@ -2461,14 +3013,21 @@
 			}
 		},
 		"node_modules/fastq": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.6.10",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+			"integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/figures": {
 			"version": "3.2.0",
@@ -2565,9 +3124,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -2575,6 +3134,7 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
 			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"license": "MIT",
 			"dependencies": {
 				"is-callable": "^1.2.7"
 			},
@@ -2585,12 +3145,57 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -2601,17 +3206,31 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+			"integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-			"integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
+				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.0",
+				"get-proto": "^1.0.1",
 				"gopd": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"hasown": "^2.0.2",
@@ -2628,6 +3247,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
 				"es-object-atoms": "^1.0.0"
@@ -2732,6 +3352,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -2786,6 +3407,52 @@
 				"typescript": ">=3"
 			}
 		},
+		"node_modules/gts/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/gts/node_modules/prettier": {
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+			"integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/gts/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/guid-typescript": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
@@ -2816,6 +3483,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
@@ -2827,6 +3495,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -2838,6 +3507,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
 			},
@@ -2852,6 +3522,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
 			"integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.4",
 				"safe-buffer": "^5.2.1"
@@ -2864,6 +3535,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -2881,10 +3553,21 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
 		"node_modules/hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+			"license": "MIT",
 			"dependencies": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -2944,7 +3627,8 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -2957,9 +3641,9 @@
 			}
 		},
 		"node_modules/import-fresh": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3031,6 +3715,13 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
 		},
+		"node_modules/inline-style-parser": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+			"integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/inquirer": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
@@ -3056,6 +3747,36 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/inquirer/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/inquirer/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/interpret": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
@@ -3070,6 +3791,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
 			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -3088,10 +3810,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -3100,9 +3836,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3139,6 +3875,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
 			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"get-proto": "^1.0.0",
@@ -3163,6 +3900,19 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-interactive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
@@ -3224,6 +3974,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"gopd": "^1.2.0",
@@ -3254,6 +4005,7 @@
 			"version": "1.1.15",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
 			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"license": "MIT",
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
 			},
@@ -3264,10 +4016,24 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-unicode-supported": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -3286,6 +4052,45 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/its-fine": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+			"integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/react-reconciler": "^0.28.0"
+			},
+			"peerDependencies": {
+				"react": ">=18.0"
+			}
+		},
+		"node_modules/its-fine/node_modules/@types/react-reconciler": {
+			"version": "0.28.9",
+			"resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+			"integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
 		"node_modules/jest-worker": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -3301,20 +4106,14 @@
 				"node": ">= 10.13.0"
 			}
 		},
-		"node_modules/jest-worker/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+		"node_modules/jiti": {
+			"version": "1.21.7",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			"bin": {
+				"jiti": "bin/jiti.js"
 			}
 		},
 		"node_modules/js-tokens": {
@@ -3401,12 +4200,12 @@
 			}
 		},
 		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+			"integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
 			"license": "MIT",
 			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
+				"buffer-equal-constant-time": "^1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
 				"safe-buffer": "^5.0.1"
 			}
@@ -3450,6 +4249,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3462,6 +4271,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lilconfig": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/lines-and-columns": {
@@ -3562,6 +4381,49 @@
 			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"license": "MIT"
 		},
+		"node_modules/log-symbols": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"is-unicode-supported": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols/node_modules/is-unicode-supported": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3599,6 +4461,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -3607,6 +4470,7 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"license": "MIT",
 			"dependencies": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -3670,6 +4534,13 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/meshoptimizer": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+			"integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3688,6 +4559,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
@@ -3697,9 +4569,10 @@
 			}
 		},
 		"node_modules/miller-rabin/node_modules/bn.js": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-			"integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"license": "MIT"
 		},
 		"node_modules/mime-db": {
 			"version": "1.52.0",
@@ -3734,6 +4607,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -3747,12 +4633,14 @@
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"license": "ISC"
 		},
 		"node_modules/minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+			"license": "MIT"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -3782,10 +4670,20 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
 		"node_modules/mute-stream": {
@@ -3794,6 +4692,37 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -3826,6 +4755,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/node-html-parser": {
+			"version": "6.1.13",
+			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+			"integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-select": "^5.1.0",
+				"he": "1.2.0"
+			}
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.19",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -3849,6 +4789,16 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -3860,6 +4810,39 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-hash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/observable-fns": {
@@ -3910,6 +4893,146 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/ora": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+			"integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"cli-cursor": "^5.0.0",
+				"cli-spinners": "^2.9.2",
+				"is-interactive": "^2.0.0",
+				"is-unicode-supported": "^2.0.0",
+				"log-symbols": "^6.0.0",
+				"stdin-discarder": "^0.2.2",
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ora/node_modules/cli-cursor": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/emoji-regex": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ora/node_modules/onetime": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/restore-cursor": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^7.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ora/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/os-tmpdir": {
@@ -3964,6 +5087,13 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3981,6 +5111,7 @@
 			"version": "5.1.7",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
 			"integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+			"license": "ISC",
 			"dependencies": {
 				"asn1.js": "^4.10.1",
 				"browserify-aes": "^1.2.0",
@@ -4049,6 +5180,30 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -4060,18 +5215,51 @@
 			}
 		},
 		"node_modules/pbkdf2": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-			"integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+			"integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
+			"license": "MIT",
 			"dependencies": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"create-hash": "~1.1.3",
+				"create-hmac": "^1.1.7",
+				"ripemd160": "=2.0.1",
+				"safe-buffer": "^5.2.1",
+				"sha.js": "^2.4.11",
+				"to-buffer": "^1.2.0"
 			},
 			"engines": {
 				"node": ">=0.12"
+			}
+		},
+		"node_modules/pbkdf2/node_modules/create-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+			"integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+			"license": "MIT",
+			"dependencies": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"node_modules/pbkdf2/node_modules/hash-base": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+			"integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.1"
+			}
+		},
+		"node_modules/pbkdf2/node_modules/ripemd160": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+			"integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+			"license": "MIT",
+			"dependencies": {
+				"hash-base": "^2.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"node_modules/picocolors": {
@@ -4092,6 +5280,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -4167,9 +5375,198 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
 			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/postcss": {
+			"version": "8.4.31",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.6",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.2"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-css-variables": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/postcss-css-variables/-/postcss-css-variables-0.18.0.tgz",
+			"integrity": "sha512-lYS802gHbzn1GI+lXvy9MYIYDuGnl1WB4FTKoqMQqJ3Mab09A7a/1wZvGTkCEZJTM8mSbIyb1mJYn8f0aPye0Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"escape-string-regexp": "^1.0.3",
+				"extend": "^3.0.1"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.6"
+			}
+		},
+		"node_modules/postcss-css-variables/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/postcss-import": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+			"integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/postcss-js": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+			"integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"camelcase-css": "^2.0.1"
+			},
+			"engines": {
+				"node": "^12 || ^14 || >= 16"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.21"
+			}
+		},
+		"node_modules/postcss-load-config": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+			"integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"lilconfig": "^3.0.0",
+				"yaml": "^2.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"postcss": ">=8.0.9",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"postcss": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/postcss-load-config/node_modules/lilconfig": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
+			}
+		},
+		"node_modules/postcss-nested": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+			"integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"postcss-selector-parser": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=12.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.14"
+			}
+		},
+		"node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -4182,9 +5579,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-			"integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -4213,12 +5610,28 @@
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"license": "MIT"
+		},
+		"node_modules/prompts": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/public-encrypt": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -4229,9 +5642,10 @@
 			}
 		},
 		"node_modules/public-encrypt/node_modules/bn.js": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-			"integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"license": "MIT"
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -4287,9 +5701,90 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"license": "MIT",
 			"dependencies": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/react": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.2"
+			},
+			"peerDependencies": {
+				"react": "^18.3.1"
+			}
+		},
+		"node_modules/react-dom/node_modules/scheduler": {
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
+		},
+		"node_modules/react-reconciler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+			"integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.21.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/react-use-measure": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+			"integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.13",
+				"react-dom": ">=16.13"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^2.3.0"
 			}
 		},
 		"node_modules/read-pkg": {
@@ -4436,6 +5931,7 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"license": "MIT",
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -4449,7 +5945,21 @@
 		"node_modules/readable-stream/node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
+		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
 		},
 		"node_modules/rechoir": {
 			"version": "0.8.0",
@@ -4502,18 +6012,21 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"version": "1.22.10",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.13.0",
+				"is-core-module": "^2.16.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
 			"bin": {
 				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -4567,9 +6080,9 @@
 			}
 		},
 		"node_modules/reusify": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4598,6 +6111,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"license": "MIT",
 			"dependencies": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
@@ -4674,6 +6188,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
 			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -4693,10 +6208,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/scheduler": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+			"integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
+		},
 		"node_modules/schema-utils": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4751,9 +6276,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -4776,6 +6301,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -4789,15 +6315,23 @@
 			}
 		},
 		"node_modules/sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+			"license": "(MIT AND BSD-3-Clause)",
 			"dependencies": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "^2.0.4",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.0"
 			},
 			"bin": {
 				"sha.js": "bin.js"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/shallow-clone": {
@@ -4843,6 +6377,13 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4854,13 +6395,23 @@
 			}
 		},
 		"node_modules/source-map": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 12"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-support": {
@@ -4914,16 +6465,30 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.20",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-			"integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+			"version": "3.0.22",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
 			"dev": true,
 			"license": "CC0-1.0"
+		},
+		"node_modules/stdin-discarder": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+			"integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/stream-browserify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
 			"integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "~2.0.4",
 				"readable-stream": "^3.5.0"
@@ -4933,6 +6498,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -4946,6 +6512,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -4953,7 +6520,8 @@
 		"node_modules/string_decoder/node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
@@ -4970,7 +6538,37 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5019,17 +6617,100 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/sucrase": {
+			"version": "3.35.0",
+			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+			"integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"commander": "^4.0.0",
+				"glob": "^10.3.10",
+				"lines-and-columns": "^1.1.6",
+				"mz": "^2.7.0",
+				"pirates": "^4.0.1",
+				"ts-interface-checker": "^0.1.9"
+			},
+			"bin": {
+				"sucrase": "bin/sucrase",
+				"sucrase-node": "bin/sucrase-node"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/sucrase/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/sucrase/node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/sucrase/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/sucrase/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -5043,6 +6724,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/suspend-react": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+			"integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=17.0"
 			}
 		},
 		"node_modules/synckit": {
@@ -5063,16 +6754,62 @@
 			}
 		},
 		"node_modules/synckit/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
 			"license": "0BSD"
 		},
+		"node_modules/tailwindcss": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
+			"integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@alloc/quick-lru": "^5.2.0",
+				"arg": "^5.0.2",
+				"chokidar": "^3.5.3",
+				"didyoumean": "^1.2.2",
+				"dlv": "^1.1.3",
+				"fast-glob": "^3.2.12",
+				"glob-parent": "^6.0.2",
+				"is-glob": "^4.0.3",
+				"jiti": "^1.18.2",
+				"lilconfig": "^2.1.0",
+				"micromatch": "^4.0.5",
+				"normalize-path": "^3.0.0",
+				"object-hash": "^3.0.0",
+				"picocolors": "^1.0.0",
+				"postcss": "^8.4.23",
+				"postcss-import": "^15.1.0",
+				"postcss-js": "^4.0.1",
+				"postcss-load-config": "^4.0.1",
+				"postcss-nested": "^6.0.1",
+				"postcss-selector-parser": "^6.0.11",
+				"postcss-value-parser": "^4.2.0",
+				"resolve": "^1.22.2",
+				"sucrase": "^3.32.0"
+			},
+			"bin": {
+				"tailwind": "lib/cli.js",
+				"tailwindcss": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/arg": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+			"integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5080,14 +6817,14 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-			"integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+			"version": "5.43.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+			"integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.8.2",
+				"acorn": "^8.14.0",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -5099,9 +6836,9 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.11",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
-			"integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+			"version": "5.3.14",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
+			"integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5134,9 +6871,9 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.30",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+			"integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5144,12 +6881,42 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
 		},
 		"node_modules/threads": {
 			"version": "1.7.0",
@@ -5168,6 +6935,12 @@
 			"optionalDependencies": {
 				"tiny-worker": ">= 2"
 			}
+		},
+		"node_modules/three": {
+			"version": "0.160.1",
+			"resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
+			"integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
+			"license": "MIT"
 		},
 		"node_modules/through": {
 			"version": "2.3.8",
@@ -5199,6 +6972,26 @@
 				"node": ">=0.6.0"
 			}
 		},
+		"node_modules/to-buffer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+			"integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+			"license": "MIT",
+			"dependencies": {
+				"isarray": "^2.0.5",
+				"safe-buffer": "^5.2.1",
+				"typed-array-buffer": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/to-buffer/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"license": "MIT"
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5222,6 +7015,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/ts-interface-checker": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/ts-loader": {
 			"version": "9.5.2",
 			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.2.tgz",
@@ -5241,6 +7041,36 @@
 			"peerDependencies": {
 				"typescript": "*",
 				"webpack": "^5.0.0"
+			}
+		},
+		"node_modules/ts-loader/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ts-loader/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/ts-node": {
@@ -5310,6 +7140,21 @@
 				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
+		"node_modules/tw-to-css": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/tw-to-css/-/tw-to-css-0.0.12.tgz",
+			"integrity": "sha512-rQAsQvOtV1lBkyCw+iypMygNHrShYAItES5r8fMsrhhaj5qrV2LkZyXc8ccEH+u5bFjHjQ9iuxe90I7Kykf6pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"postcss": "8.4.31",
+				"postcss-css-variables": "0.18.0",
+				"tailwindcss": "3.3.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5336,6 +7181,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "4.9.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -5351,16 +7210,16 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-			"integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5398,10 +7257,21 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+			"integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/util": {
 			"version": "0.12.5",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
 			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"is-arguments": "^1.0.4",
@@ -5413,7 +7283,8 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
 		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -5436,12 +7307,13 @@
 		"node_modules/vm-browserify": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+			"license": "MIT"
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
+			"integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5453,21 +7325,23 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.98.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
-			"integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+			"version": "5.101.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.1.tgz",
+			"integrity": "sha512-rHY3vHXRbkSfhG6fH8zYQdth/BtDgXXuR2pHF++1f/EBkI8zkgM5XWfsC3BvOoW9pr1CvZ1qQCxhCEsbNgT50g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
-				"@types/estree": "^1.0.6",
+				"@types/estree": "^1.0.8",
+				"@types/json-schema": "^7.0.15",
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.14.0",
+				"acorn": "^8.15.0",
+				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.24.0",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.1",
+				"enhanced-resolve": "^5.17.3",
 				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -5477,11 +7351,11 @@
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^4.3.0",
+				"schema-utils": "^4.3.2",
 				"tapable": "^2.1.1",
 				"terser-webpack-plugin": "^5.3.11",
 				"watchpack": "^2.4.1",
-				"webpack-sources": "^3.2.3"
+				"webpack-sources": "^3.3.3"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -5542,16 +7416,6 @@
 				}
 			}
 		},
-		"node_modules/webpack-cli/node_modules/commander": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/webpack-merge": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
@@ -5568,9 +7432,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5594,14 +7458,16 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.18",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-			"integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"for-each": "^0.3.3",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
 				"gopd": "^1.2.0",
 				"has-tostringtag": "^1.0.2"
 			},
@@ -5627,6 +7493,110 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/wrappy": {
@@ -5656,6 +7626,19 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			}
 		},
 		"node_modules/yargs-parser": {
 			"version": "20.2.9",
@@ -5688,6 +7671,41 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoga-layout": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+			"integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zustand": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+			"integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.7.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				}
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
 	"author": "ArborXR <devs@arborxr.com> (https://arborxr.com)",
 	"license": "ISC",
 	"devDependencies": {
+		"@react-three/fiber": "^8.15.0",
+		"@react-three/uikit": "^0.8.0",
 		"@types/jsonwebtoken": "^9.0.6",
 		"@types/node": "^22.9.1",
 		"@types/react": "^18.2.0",
 		"@types/react-dom": "^18.2.0",
 		"@types/three": "^0.160.0",
+		"gts": "^5.3.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"@react-three/fiber": "^8.15.0",
-		"@react-three/uikit": "^0.8.0",
-		"gts": "^5.3.1",
 		"ts-loader": "^9.5.2",
 		"ts-node": "^10.9.2",
 		"typescript": "^4.9.5",
@@ -45,17 +45,17 @@
 		"webpack-cli": "^6.0.1"
 	},
 	"dependencies": {
-		"vm-browserify": "^1.1.2",
-		"util": "^0.12.5",
 		"buffer": "^6.0.3",
-		"stream-browserify": "^3.0.0",
 		"crypto-browserify": "^3.12.1",
 		"guid-typescript": "^1.0.9",
 		"jsonwebtoken": "^9.0.2",
 		"jwt-decode": "^4.0.0",
 		"localStorage": "^1.0.4",
+		"stream-browserify": "^3.0.0",
 		"threads": "^1.7.0",
-		"three": "^0.160.0"
+		"three": "^0.160.0",
+		"util": "^0.12.5",
+		"vm-browserify": "^1.1.2"
 	},
 	"files": [
 		"index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
 		"pretest": "npm run compile",
 		"posttest": "npm run lint",
 		"test": "ts-node src/test.ts",
-		"debug": "node --import ts-node/register/transpile-only --inspect-brk src/test.ts"
+		"debug": "node --import ts-node/register/transpile-only --inspect-brk src/test.ts",
+		"changelog": "node scripts/generate-changelog.js",
+		"changelog:version": "node scripts/generate-changelog.js --version"
 	},
 	"engines": {
 		"node": ">=16.0.0"

--- a/publish-with-changelog.sh
+++ b/publish-with-changelog.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+# AbxrLib Publish Script with Changelog Generation
+# This script runs on the host system and orchestrates:
+# 1. Docker build and npm publish
+# 2. Git tagging
+# 3. Changelog generation
+
+set -e
+
+echo "🚀 Starting AbxrLib publish process..."
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "❌ Error: Not in a git repository"
+    exit 1
+fi
+
+# Check for uncommitted changes
+if ! git diff-index --quiet HEAD --; then
+    echo "⚠️  Warning: You have uncommitted changes. Consider committing them first."
+    read -p "Continue anyway? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 1
+    fi
+fi
+
+# Check if .env file exists
+if [ ! -f ".env" ]; then
+    echo "❌ Error: .env file not found. Please create it with your NPM_TOKEN."
+    echo "Example:"
+    echo "NPM_TOKEN=your_npm_token_here"
+    exit 1
+fi
+
+# Get current version from npm registry
+echo "📦 Checking current published version..."
+CURRENT_VERSION=$(npm view abxrlib-for-webxr version 2>/dev/null || echo "0.0.0")
+echo "Current published version: $CURRENT_VERSION"
+
+# Calculate next version
+IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
+new_patch=$((patch + 1))
+NEXT_VERSION="${major}.${minor}.${new_patch}"
+echo "Next version will be: $NEXT_VERSION"
+
+# Create a temporary directory for version exchange
+TEMP_DIR=$(mktemp -d)
+echo "Using temp directory: $TEMP_DIR"
+
+# Run Docker build and publish
+echo "🐳 Running Docker build and publish..."
+docker-compose down 2>/dev/null || true
+
+# Run the publish with volume mount to get the version back
+docker-compose -f docker-compose-publish.yml up --build
+
+# Check if Docker publish was successful by looking for the version file
+PUBLISHED_VERSION=""
+CONTAINER_ID=$(docker ps -aq --filter "name=abxrlib-for-webxr")
+
+if [ -n "$CONTAINER_ID" ]; then
+    # Try to copy the version file from the container
+    if docker cp "$CONTAINER_ID:/tmp/published_version.txt" "$TEMP_DIR/published_version.txt" 2>/dev/null; then
+        PUBLISHED_VERSION=$(cat "$TEMP_DIR/published_version.txt" 2>/dev/null || echo "")
+    fi
+fi
+
+# Clean up Docker
+docker-compose down 2>/dev/null || true
+
+# Check if we got a version back
+if [ -z "$PUBLISHED_VERSION" ]; then
+    echo "❌ Could not determine published version. Checking if publish was successful..."
+    
+    # Double-check by querying npm registry
+    LATEST_VERSION=$(npm view abxrlib-for-webxr version 2>/dev/null || echo "0.0.0")
+    if [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
+        PUBLISHED_VERSION="$LATEST_VERSION"
+        echo "✅ Detected new version from npm registry: $PUBLISHED_VERSION"
+    else
+        echo "❌ Publish appears to have failed. No new version detected."
+        cleanup_and_exit 1
+    fi
+fi
+
+echo "✅ Successfully published version: $PUBLISHED_VERSION"
+
+# Function to cleanup and exit
+cleanup_and_exit() {
+    rm -rf "$TEMP_DIR" 2>/dev/null || true
+    exit ${1:-0}
+}
+
+# Generate changelog for this version
+echo "📝 Generating changelog for version $PUBLISHED_VERSION..."
+if [ -f "scripts/generate-changelog.js" ]; then
+    if node scripts/generate-changelog.js --version "$PUBLISHED_VERSION"; then
+        echo "✅ Changelog updated successfully"
+        
+        # Add changelog to git if it was modified
+        if git diff --quiet CHANGELOG.md; then
+            echo "ℹ️  No changelog changes to commit"
+        else
+            echo "📝 Committing changelog updates..."
+            git add CHANGELOG.md
+            git commit -m "docs: update changelog for version $PUBLISHED_VERSION"
+        fi
+    else
+        echo "⚠️  Warning: Changelog generation failed, but continuing..."
+    fi
+else
+    echo "⚠️  Warning: Changelog generator not found at scripts/generate-changelog.js"
+fi
+
+# Create git tag for this version
+echo "🏷️  Creating git tag v$PUBLISHED_VERSION..."
+if git tag -a "v$PUBLISHED_VERSION" -m "Release version $PUBLISHED_VERSION"; then
+    echo "✅ Git tag v$PUBLISHED_VERSION created successfully"
+else
+    echo "⚠️  Warning: Could not create git tag (may already exist)"
+fi
+
+# Ask about pushing to remote
+echo ""
+echo "🎉 Publish process completed successfully!"
+echo ""
+echo "📋 Summary:"
+echo "  • Published version: $PUBLISHED_VERSION"
+echo "  • Git tag created: v$PUBLISHED_VERSION"
+echo "  • Changelog updated: ✅"
+echo ""
+echo "🔄 Next steps:"
+echo "  1. Review the changelog: cat CHANGELOG.md"
+echo "  2. Push changes to remote:"
+echo "     git push origin main"
+echo "     git push origin v$PUBLISHED_VERSION"
+echo ""
+
+read -p "Push changes to remote now? (y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "📤 Pushing to remote..."
+    
+    # Push main branch
+    if git push origin main; then
+        echo "✅ Pushed main branch"
+    else
+        echo "⚠️  Warning: Could not push main branch"
+    fi
+    
+    # Push tag
+    if git push origin "v$PUBLISHED_VERSION"; then
+        echo "✅ Pushed tag v$PUBLISHED_VERSION"
+    else
+        echo "⚠️  Warning: Could not push tag"
+    fi
+    
+    echo "🎉 All done!"
+else
+    echo "ℹ️  Remember to push manually when ready:"
+    echo "   git push origin main && git push origin v$PUBLISHED_VERSION"
+fi
+
+# Cleanup
+cleanup_and_exit 0

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Generate changelog from git commits between tags
+ */
+class ChangelogGenerator {
+  constructor() {
+    this.changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
+  }
+
+  /**
+   * Execute git command and return output
+   */
+  execGit(command) {
+    try {
+      return execSync(`git ${command}`, { encoding: 'utf8' }).trim();
+    } catch (error) {
+      console.error(`Error executing git command: ${command}`);
+      console.error(error.message);
+      return '';
+    }
+  }
+
+  /**
+   * Get all git tags sorted by version
+   */
+  getTags() {
+    const tags = this.execGit('tag --list --sort=-version:refname');
+    return tags ? tags.split('\n').filter(tag => tag.trim()) : [];
+  }
+
+  /**
+   * Get commits between two references
+   */
+  getCommitsBetween(from, to) {
+    const range = from ? `${from}..${to}` : to;
+    const commits = this.execGit(`log ${range} --pretty=format:"%H|%s|%an|%ad" --date=short`);
+    
+    if (!commits) return [];
+    
+    return commits.split('\n').map(line => {
+      const [hash, subject, author, date] = line.split('|');
+      return { hash, subject, author, date };
+    });
+  }
+
+  /**
+   * Categorize commit based on conventional commit format
+   */
+  categorizeCommit(subject) {
+    const conventionalPattern = /^(feat|fix|docs|style|refactor|test|chore|perf|ci|build)(\(.+\))?\s*:\s*(.+)/i;
+    const match = subject.match(conventionalPattern);
+    
+    if (match) {
+      const [, type, scope, description] = match;
+      return {
+        type: type.toLowerCase(),
+        scope: scope ? scope.slice(1, -1) : null, // Remove parentheses
+        description,
+        isConventional: true
+      };
+    }
+    
+    // Try to categorize non-conventional commits
+    const lowerSubject = subject.toLowerCase();
+    if (lowerSubject.includes('fix') || lowerSubject.includes('bug')) {
+      return { type: 'fix', scope: null, description: subject, isConventional: false };
+    }
+    if (lowerSubject.includes('add') || lowerSubject.includes('feature')) {
+      return { type: 'feat', scope: null, description: subject, isConventional: false };
+    }
+    if (lowerSubject.includes('update') || lowerSubject.includes('improve')) {
+      return { type: 'refactor', scope: null, description: subject, isConventional: false };
+    }
+    
+    return { type: 'other', scope: null, description: subject, isConventional: false };
+  }
+
+  /**
+   * Format commit for changelog
+   */
+  formatCommit(commit, category) {
+    const shortHash = commit.hash.substring(0, 7);
+    const scope = category.scope ? `**${category.scope}**: ` : '';
+    return `- ${scope}${category.description} ([${shortHash}](../../commit/${commit.hash}))`;
+  }
+
+  /**
+   * Generate changelog section for a version
+   */
+  generateVersionSection(version, commits, date) {
+    if (commits.length === 0) {
+      return `## [${version}] - ${date}\n\n*No changes recorded*\n\n`;
+    }
+
+    const categorized = {
+      feat: [],
+      fix: [],
+      refactor: [],
+      docs: [],
+      style: [],
+      test: [],
+      chore: [],
+      perf: [],
+      ci: [],
+      build: [],
+      other: []
+    };
+
+    commits.forEach(commit => {
+      const category = this.categorizeCommit(commit.subject);
+      categorized[category.type].push({ commit, category });
+    });
+
+    let section = `## [${version}] - ${date}\n\n`;
+
+    // Features
+    if (categorized.feat.length > 0) {
+      section += '### ✨ Features\n\n';
+      categorized.feat.forEach(({ commit, category }) => {
+        section += this.formatCommit(commit, category) + '\n';
+      });
+      section += '\n';
+    }
+
+    // Bug Fixes
+    if (categorized.fix.length > 0) {
+      section += '### 🐛 Bug Fixes\n\n';
+      categorized.fix.forEach(({ commit, category }) => {
+        section += this.formatCommit(commit, category) + '\n';
+      });
+      section += '\n';
+    }
+
+    // Performance
+    if (categorized.perf.length > 0) {
+      section += '### ⚡ Performance\n\n';
+      categorized.perf.forEach(({ commit, category }) => {
+        section += this.formatCommit(commit, category) + '\n';
+      });
+      section += '\n';
+    }
+
+    // Refactoring
+    if (categorized.refactor.length > 0) {
+      section += '### ♻️ Refactoring\n\n';
+      categorized.refactor.forEach(({ commit, category }) => {
+        section += this.formatCommit(commit, category) + '\n';
+      });
+      section += '\n';
+    }
+
+    // Documentation
+    if (categorized.docs.length > 0) {
+      section += '### 📚 Documentation\n\n';
+      categorized.docs.forEach(({ commit, category }) => {
+        section += this.formatCommit(commit, category) + '\n';
+      });
+      section += '\n';
+    }
+
+    // Build/CI
+    const buildAndCI = [...categorized.build, ...categorized.ci];
+    if (buildAndCI.length > 0) {
+      section += '### 🔧 Build & CI\n\n';
+      buildAndCI.forEach(({ commit, category }) => {
+        section += this.formatCommit(commit, category) + '\n';
+      });
+      section += '\n';
+    }
+
+    // Other changes
+    const otherChanges = [...categorized.chore, ...categorized.style, ...categorized.test, ...categorized.other];
+    if (otherChanges.length > 0) {
+      section += '### 🔨 Other Changes\n\n';
+      otherChanges.forEach(({ commit, category }) => {
+        section += this.formatCommit(commit, category) + '\n';
+      });
+      section += '\n';
+    }
+
+    return section;
+  }
+
+  /**
+   * Generate full changelog
+   */
+  generateChangelog() {
+    console.log('Generating changelog...');
+    
+    const tags = this.getTags();
+    const currentDate = new Date().toISOString().split('T')[0];
+    
+    let changelog = `# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n`;
+
+    if (tags.length === 0) {
+      // No tags yet, get all commits
+      const allCommits = this.getCommitsBetween(null, 'HEAD');
+      changelog += this.generateVersionSection('Unreleased', allCommits, currentDate);
+    } else {
+      // Get unreleased commits (since last tag)
+      const unreleasedCommits = this.getCommitsBetween(tags[0], 'HEAD');
+      if (unreleasedCommits.length > 0) {
+        changelog += this.generateVersionSection('Unreleased', unreleasedCommits, currentDate);
+      }
+
+      // Generate sections for each tag
+      for (let i = 0; i < tags.length; i++) {
+        const currentTag = tags[i];
+        const previousTag = tags[i + 1];
+        
+        const commits = this.getCommitsBetween(previousTag, currentTag);
+        const tagDate = this.execGit(`log -1 --format=%ad --date=short ${currentTag}`);
+        
+        changelog += this.generateVersionSection(currentTag, commits, tagDate || currentDate);
+      }
+    }
+
+    return changelog;
+  }
+
+  /**
+   * Update changelog for a specific version
+   */
+  updateChangelogForVersion(version) {
+    console.log(`Updating changelog for version ${version}...`);
+    
+    const tags = this.getTags();
+    const currentDate = new Date().toISOString().split('T')[0);
+    
+    // Find the previous tag
+    const versionTag = `v${version}`;
+    const tagIndex = tags.indexOf(versionTag);
+    const previousTag = tagIndex < tags.length - 1 ? tags[tagIndex + 1] : null;
+    
+    // Get commits for this version
+    const commits = this.getCommitsBetween(previousTag, 'HEAD');
+    
+    if (commits.length === 0) {
+      console.log('No new commits found for changelog.');
+      return;
+    }
+    
+    const versionSection = this.generateVersionSection(version, commits, currentDate);
+    
+    // Read existing changelog or create header
+    let existingChangelog = '';
+    if (fs.existsSync(this.changelogPath)) {
+      existingChangelog = fs.readFileSync(this.changelogPath, 'utf8');
+    } else {
+      existingChangelog = `# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n`;
+    }
+    
+    // Insert new version section after the header
+    const headerEndIndex = existingChangelog.indexOf('\n\n') + 2;
+    const newChangelog = existingChangelog.slice(0, headerEndIndex) + versionSection + existingChangelog.slice(headerEndIndex);
+    
+    fs.writeFileSync(this.changelogPath, newChangelog);
+    console.log(`Changelog updated for version ${version}`);
+  }
+
+  /**
+   * Write full changelog to file
+   */
+  writeChangelog() {
+    const changelog = this.generateChangelog();
+    fs.writeFileSync(this.changelogPath, changelog);
+    console.log(`Changelog written to ${this.changelogPath}`);
+  }
+}
+
+// CLI usage
+if (require.main === module) {
+  const generator = new ChangelogGenerator();
+  const args = process.argv.slice(2);
+  
+  if (args.length > 0 && args[0] === '--version') {
+    const version = args[1];
+    if (!version) {
+      console.error('Please provide a version number: --version 1.0.21');
+      process.exit(1);
+    }
+    generator.updateChangelogForVersion(version);
+  } else {
+    generator.writeChangelog();
+  }
+}
+
+module.exports = ChangelogGenerator;

--- a/src/AbxrLibAnalytics.ts
+++ b/src/AbxrLibAnalytics.ts
@@ -7,7 +7,7 @@ import { Base64, CurlHttp, DATEMAXVALUE, Sleep } from './network/types';
 import { crc32 } from './network/utils/crc32';
 import { sha256, SHA256 } from './network/utils/cryptoUtils';
 import { DataObjectBase, DbSet, FieldPropertyFlags, LoadFromJson } from './network/utils/DataObjectBase';
-import { AbxrResult, DateTime, TimeSpan, StringList, AbxrDictStrings, JsonResult } from './network/utils/DotNetishTypes';
+import { AbxrResult, DateTime, TimeSpan, StringList, AbxrDictStrings, JsonSuccess, JsonResult } from './network/utils/DotNetishTypes';
 import { DatabaseResult } from './network/utils/AbxrLibSQLite';
 import { JWTDecode } from './network/utils/JWT';
 
@@ -170,13 +170,13 @@ export class AbxrLibInit
 			var	objAuthTokenResponseFailure:	AuthTokenResponseFailure = new AuthTokenResponseFailure();
 			var	objAuthTokenDecodedJWT:			AuthTokenDecodedJWT = new AuthTokenDecodedJWT();
 
-			eSuccessParse = LoadFromJson(objAuthTokenResponseSuccess, rpResponse.szResponse);
-			eFailureParse = LoadFromJson(objAuthTokenResponseFailure, rpResponse.szResponse);
+			eSuccessParse = LoadFromJson(objAuthTokenResponseSuccess, rpResponse.szResponse, false);
+			eFailureParse = LoadFromJson(objAuthTokenResponseFailure, rpResponse.szResponse, false);
 			if (eSuccessParse === JsonResult.eBadJsonStructure || eFailureParse === JsonResult.eBadJsonStructure)
 			{
 				eRet = AbxrResult.eCorruptJson;
 			}
-			else if (eSuccessParse === JsonResult.eOk)
+			else if (JsonSuccess(eSuccessParse) && objAuthTokenResponseSuccess.IsValid())
 			{
 				var	szJWT: string;
 
@@ -221,8 +221,8 @@ export class AbxrLibInit
 				// --- AbxrLibInit.m_abxrLibAuthentication.m_szApiToken is a JWT token that contains, among other things, an "exp"
 				//		field which is the Unix time of token expiration.
 				szJWT = JWTDecode(AbxrLibInit.m_abxrLibAuthentication.m_szApiToken);
-				eJWTParse = LoadFromJson(objAuthTokenDecodedJWT, szJWT);
-				if (eJWTParse === JsonResult.eOk)
+				eJWTParse = LoadFromJson(objAuthTokenDecodedJWT, szJWT, false);
+				if (JsonSuccess(eJWTParse) && objAuthTokenDecodedJWT.IsValid())
 				{
 					AbxrLibInit.m_abxrLibAuthentication.m_dtTokenExpiration.FromUnixTime(objAuthTokenDecodedJWT.m_utTokenExpiration);
 				}
@@ -755,13 +755,13 @@ export class AbxrLibAnalytics
 							var	objResponseSuccess:	PostObjectsResponseSuccess = new PostObjectsResponseSuccess();
 							var	objResponseFailure:	PostObjectsResponseFailure = new PostObjectsResponseFailure();
 
-							eSuccessParse = LoadFromJson(objResponseSuccess, rpResponse.szResponse);
-							eFailureParse = LoadFromJson(objResponseFailure, rpResponse.szResponse);
+							eSuccessParse = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false);
+							eFailureParse = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
 							if (eSuccessParse === JsonResult.eBadJsonStructure || eFailureParse === JsonResult.eBadJsonStructure)
 							{
 								eTestRet = AbxrResult.eCorruptJson;
 							}
-							else if (eSuccessParse === JsonResult.eOk)
+							else if (JsonSuccess(eSuccessParse) && objResponseSuccess.IsValid())
 							{
 								// Do something with the data?  Haven't seen a success yet.  TODO.
 								eTestRet = AbxrResult.eOk;
@@ -887,13 +887,13 @@ export class AbxrLibAnalytics
 								var	objResponseFailure: PostObjectsResponseFailure = new PostObjectsResponseFailure();
 								var	eTestRet:			AbxrResult = AbxrResult.eOk;
 
-								eSuccessParse = LoadFromJson(objResponseSuccess, rpResponse.szResponse);
-								eFailureParse = LoadFromJson(objResponseFailure, rpResponse.szResponse);
+								eSuccessParse = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false);
+								eFailureParse = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
 								if (eSuccessParse === JsonResult.eBadJsonStructure || eFailureParse === JsonResult.eBadJsonStructure)
 								{
 									eTestRet = AbxrResult.eCorruptJson;
 								}
-								else if (eSuccessParse === JsonResult.eOk)
+								else if (JsonSuccess(eSuccessParse) && objResponseSuccess.IsValid())
 								{
 									// Do something with the data?  Haven't seen a success yet.  TODO.
 									eTestRet = AbxrResult.eOk;

--- a/src/AbxrLibAnalytics.ts
+++ b/src/AbxrLibAnalytics.ts
@@ -169,9 +169,10 @@ export class AbxrLibInit
 			var	objAuthTokenResponseSuccess:	AuthTokenResponseSuccess = new AuthTokenResponseSuccess();
 			var	objAuthTokenResponseFailure:	AuthTokenResponseFailure = new AuthTokenResponseFailure();
 			var	objAuthTokenDecodedJWT:			AuthTokenDecodedJWT = new AuthTokenDecodedJWT();
+			var sszErrors:						Set<string> = new Set<string>;
 
-			eSuccessParse = LoadFromJson(objAuthTokenResponseSuccess, rpResponse.szResponse, false);
-			eFailureParse = LoadFromJson(objAuthTokenResponseFailure, rpResponse.szResponse, false);
+			eSuccessParse = LoadFromJson(objAuthTokenResponseSuccess, rpResponse.szResponse, false, sszErrors);
+			eFailureParse = LoadFromJson(objAuthTokenResponseFailure, rpResponse.szResponse, false, sszErrors);
 			if (eSuccessParse === JsonResult.eBadJsonStructure || eFailureParse === JsonResult.eBadJsonStructure)
 			{
 				eRet = AbxrResult.eCorruptJson;
@@ -221,7 +222,7 @@ export class AbxrLibInit
 				// --- AbxrLibInit.m_abxrLibAuthentication.m_szApiToken is a JWT token that contains, among other things, an "exp"
 				//		field which is the Unix time of token expiration.
 				szJWT = JWTDecode(AbxrLibInit.m_abxrLibAuthentication.m_szApiToken);
-				eJWTParse = LoadFromJson(objAuthTokenDecodedJWT, szJWT, false);
+				eJWTParse = LoadFromJson(objAuthTokenDecodedJWT, szJWT, false, sszErrors);
 				if (JsonSuccess(eJWTParse) && objAuthTokenDecodedJWT.IsValid())
 				{
 					AbxrLibInit.m_abxrLibAuthentication.m_dtTokenExpiration.FromUnixTime(objAuthTokenDecodedJWT.m_utTokenExpiration);
@@ -698,6 +699,7 @@ export class AbxrLibAnalytics
 	{
 		var	eRet:		AbxrResult = AbxrResult.eOk,
 			eTestRet:	AbxrResult = AbxrResult.eOk;
+		var sszErrors:	Set<string> = new Set<string>;
 
 		// If we have enough new yet-to-be-pushed-to-REST items, then do that and mark as sent.
 		if (AbxrLibStorage.m_abxrLibConfiguration.RESTConfigured())
@@ -755,8 +757,8 @@ export class AbxrLibAnalytics
 							var	objResponseSuccess:	PostObjectsResponseSuccess = new PostObjectsResponseSuccess();
 							var	objResponseFailure:	PostObjectsResponseFailure = new PostObjectsResponseFailure();
 
-							eSuccessParse = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false);
-							eFailureParse = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
+							eSuccessParse = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false, sszErrors);
+							eFailureParse = LoadFromJson(objResponseFailure, rpResponse.szResponse, false, sszErrors);
 							if (eSuccessParse === JsonResult.eBadJsonStructure || eFailureParse === JsonResult.eBadJsonStructure)
 							{
 								eTestRet = AbxrResult.eCorruptJson;
@@ -858,7 +860,8 @@ export class AbxrLibAnalytics
 	/// <returns>AbxrResult status code.</returns>
 	private static async AddXXXNoDbTask<T extends AbxrBase>(abxrT: T, tTypeOfT: any, pfnPostABXRXXX: (listpT: DbSet<T>, bOneAtATime: boolean, rpResponse: {szResponse: string}) => Promise<AbxrResult>, bOneAtATime: boolean, bNoCallbackOnSuccess: boolean, pfnStatusCallback: ((abxrXXX: T, eResult: AbxrResult, szExceptionMessage: string) => void) | null): Promise<AbxrResult>
 	{
-		var	eRet:	AbxrResult = AbxrResult.eOk;
+		var	eRet:		AbxrResult = AbxrResult.eOk;
+		var sszErrors:	Set<string> = new Set<string>;
 
 		try
 		{
@@ -887,8 +890,8 @@ export class AbxrLibAnalytics
 								var	objResponseFailure: PostObjectsResponseFailure = new PostObjectsResponseFailure();
 								var	eTestRet:			AbxrResult = AbxrResult.eOk;
 
-								eSuccessParse = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false);
-								eFailureParse = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
+								eSuccessParse = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false, sszErrors);
+								eFailureParse = LoadFromJson(objResponseFailure, rpResponse.szResponse, false, sszErrors);
 								if (eSuccessParse === JsonResult.eBadJsonStructure || eFailureParse === JsonResult.eBadJsonStructure)
 								{
 									eTestRet = AbxrResult.eCorruptJson;

--- a/src/AbxrLibClient.ts
+++ b/src/AbxrLibClient.ts
@@ -6,7 +6,7 @@ import { AbxrLibAnalytics, AbxrLibInit } from "./AbxrLibAnalytics";
 import { AbxrAIProxy, AbxrBase, AbxrEvent, AbxrLibConfiguration, AbxrLog, AbxrStorage, AbxrTelemetry, AbxrXXXContainer, RESTEndpointFromType } from "./AbxrLibCoreModel";
 import { CurlHttp, EnsureSingleEndingCharacter, JsonScalarArrayElement, SUID, time_t } from "./network/types";
 import { DataObjectBase, DbSet, DumpCategory, FieldProperties, FieldPropertiesRecordContainer, FieldPropertyFlags, GenerateJson, GenerateJsonAlternate, GenerateJsonList, LoadFromJson } from "./network/utils/DataObjectBase";
-import { AbxrResult, JsonResult, AbxrDictStrings, StringList } from "./network/utils/DotNetishTypes";
+import { AbxrResult, JsonResult, JsonSuccess, AbxrDictStrings, StringList } from "./network/utils/DotNetishTypes";
 
 // Buffer type definition for browser environments
 declare global {
@@ -140,6 +140,11 @@ export class AuthTokenDecodedJWT extends DataObjectBase
 	{
 		return AuthTokenDecodedJWT.m_mapProperties;
 	}
+	// ---
+	public IsValid(): boolean
+	{
+		return (this.m_szType.length !== 0 && this.m_szJti.length !== 0);
+	}
 };
 
 /// <summary>
@@ -159,6 +164,11 @@ export class AuthTokenResponseSuccess extends DataObjectBase
 	{
 		return AuthTokenResponseSuccess.m_mapProperties;
 	}
+	// ---
+	public IsValid(): boolean
+	{
+		return (this.m_szToken.length !== 0 && this.m_szApiSecret.length !== 0);
+	}
 };
 
 /// <summary>
@@ -176,6 +186,11 @@ export class PostObjectsResponseSuccess extends DataObjectBase
 	{
 		return PostObjectsResponseSuccess.m_mapProperties;
 	}
+	// ---
+	public IsValid(): boolean
+	{
+		return (this.m_szStatus.length !== 0);
+	}
 };
 
 /// <summary>
@@ -192,6 +207,11 @@ export class PostObjectsResponseFailure extends DataObjectBase
 	public GetMapProperties(): FieldPropertiesRecordContainer // virtual
 	{
 		return PostObjectsResponseFailure.m_mapProperties;
+	}
+	// ---
+	public IsValid(): boolean
+	{
+		return (this.m_szDetail.length !== 0);
 	}
 };
 
@@ -401,16 +421,16 @@ export class AbxrLibClient
 			// bailing on the first failure is better but I do not know for sure.
 			if (eCurlRet)
 			{
-				eJsonRet = LoadFromJson(objResponseSuccess, rpResponse.szResponse);
-				if (eJsonRet === JsonResult.eOk)
+				eJsonRet = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false);
+				if (JsonSuccess(eJsonRet) && objResponseSuccess.IsValid())
 				{
 					return AbxrResult.eOk;
 				}
 				else
 				{
 					// Did not get success, does failure parse?
-					eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse);
-					if (eJsonRet === JsonResult.eOk)
+					eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
+					if (JsonSuccess(eJsonRet) && objResponseFailure.IsValid())
 					{
 						// Failure parses, probably auth error.
 						eReauthResult = await AbxrLibInit.ReAuthenticate(true);
@@ -475,13 +495,13 @@ export class AbxrLibClient
 				try {
 					if (ptResponse)
 					{
-						eJsonRet = LoadFromJson(ptResponse, rpResponse.szResponse);
+						eJsonRet = LoadFromJson(ptResponse, rpResponse.szResponse, false);
 					}
 					else
 					{
-						eJsonRet = LoadFromJson(ptContainedResponse, rpResponse.szResponse);
+						eJsonRet = LoadFromJson(ptContainedResponse, rpResponse.szResponse, false);
 					}
-					if (eJsonRet === JsonResult.eOk)
+					if (JsonSuccess(eJsonRet))
 					{
 						return AbxrResult.eOk;
 					}
@@ -491,8 +511,8 @@ export class AbxrLibClient
 				}
 
 				// Did not get success, does failure parse?
-				eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse);
-				if (eJsonRet === JsonResult.eOk)
+				eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
+				if (JsonSuccess(eJsonRet))
 				{
 					// Failure parses, probably auth error.
 					eReauthResult = await AbxrLibInit.ReAuthenticate(true);
@@ -539,16 +559,16 @@ export class AbxrLibClient
 			// OUTPUTDEBUGSTRING(szResponse, "\n");
 			if (eCurlRet)
 			{
-				eJsonRet = LoadFromJson(objResponseSuccess, rpResponse.szResponse);
-				if (eJsonRet === JsonResult.eOk)
+				eJsonRet = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false);
+				if (JsonSuccess(eJsonRet) && objResponseSuccess.IsValid())
 				{
 					return AbxrResult.eOk;
 				}
 				else
 				{
 					// Did not get success, does failure parse?
-					eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse);
-					if (eJsonRet === JsonResult.eOk)
+					eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
+					if (JsonSuccess(eJsonRet) && objResponseFailure.IsValid())
 					{
 						// Failure parses, probably auth error.
 						eReauthResult = await AbxrLibInit.ReAuthenticate(true);

--- a/src/AbxrLibClient.ts
+++ b/src/AbxrLibClient.ts
@@ -378,6 +378,7 @@ export class AbxrLibClient
 			var	mbBodyContent:		Buffer = Buffer.from("");
 			var	objResponseSuccess:	PostObjectsResponseSuccess = new PostObjectsResponseSuccess();	// e.g. {"status":"success"}
 			var	objResponseFailure:	PostObjectsResponseFailure = new PostObjectsResponseFailure();	// e.g. {"detail":"Invalid Login - Hash"}
+			var sszErrors:			Set<string> = new Set<string>;
 
 			if (bOneAtATime)
 			{
@@ -421,7 +422,7 @@ export class AbxrLibClient
 			// bailing on the first failure is better but I do not know for sure.
 			if (eCurlRet)
 			{
-				eJsonRet = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false);
+				eJsonRet = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false, sszErrors);
 				if (JsonSuccess(eJsonRet) && objResponseSuccess.IsValid())
 				{
 					return AbxrResult.eOk;
@@ -429,7 +430,7 @@ export class AbxrLibClient
 				else
 				{
 					// Did not get success, does failure parse?
-					eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
+					eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false, sszErrors);
 					if (JsonSuccess(eJsonRet) && objResponseFailure.IsValid())
 					{
 						// Failure parses, probably auth error.
@@ -471,6 +472,7 @@ export class AbxrLibClient
 			var	eReauthResult:		AbxrResult;
 			var	rpResponse:			{szResponse: string} = {szResponse: ""};
 			var	objResponseFailure:	PostObjectsResponseFailure = new PostObjectsResponseFailure();	// e.g. {"detail":"Invalid Login - Hash"}
+			var sszErrors:			Set<string> = new Set<string>;
 
 			await AbxrLibAnalytics.SetHeadersFromCurrentState(objRequest, Buffer.from(""), false, true);
 			eCurlRet = await objRequest.Get(AbxrLibAnalytics.FinalUrl(RESTEndpointFromType<T>(tTypeOfT)), vpszQueryParameters, rpResponse);
@@ -495,11 +497,11 @@ export class AbxrLibClient
 				try {
 					if (ptResponse)
 					{
-						eJsonRet = LoadFromJson(ptResponse, rpResponse.szResponse, false);
+						eJsonRet = LoadFromJson(ptResponse, rpResponse.szResponse, false, sszErrors);
 					}
 					else
 					{
-						eJsonRet = LoadFromJson(ptContainedResponse, rpResponse.szResponse, false);
+						eJsonRet = LoadFromJson(ptContainedResponse, rpResponse.szResponse, false, sszErrors);
 					}
 					if (JsonSuccess(eJsonRet))
 					{
@@ -511,7 +513,7 @@ export class AbxrLibClient
 				}
 
 				// Did not get success, does failure parse?
-				eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
+				eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false, sszErrors);
 				if (JsonSuccess(eJsonRet))
 				{
 					// Failure parses, probably auth error.
@@ -553,13 +555,14 @@ export class AbxrLibClient
 			var	eReauthResult:		AbxrResult;
 			var	objResponseSuccess:	PostObjectsResponseSuccess = new PostObjectsResponseSuccess();	// e.g. {"status":"all data reset"}
 			var	objResponseFailure:	PostObjectsResponseFailure = new PostObjectsResponseFailure();	// e.g. {"detail":"Invalid Login - Hash"}
+			var sszErrors:			Set<string> = new Set<string>;
 
 			await AbxrLibAnalytics.SetHeadersFromCurrentState(objRequest, Buffer.from(""), false, true);
 			eCurlRet = await objRequest.Delete(AbxrLibAnalytics.FinalUrl(RESTEndpointFromType<T>(tTypeOfT)), vpszQueryParameters, rpResponse);
 			// OUTPUTDEBUGSTRING(szResponse, "\n");
 			if (eCurlRet)
 			{
-				eJsonRet = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false);
+				eJsonRet = LoadFromJson(objResponseSuccess, rpResponse.szResponse, false, sszErrors);
 				if (JsonSuccess(eJsonRet) && objResponseSuccess.IsValid())
 				{
 					return AbxrResult.eOk;
@@ -567,7 +570,7 @@ export class AbxrLibClient
 				else
 				{
 					// Did not get success, does failure parse?
-					eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false);
+					eJsonRet = LoadFromJson(objResponseFailure, rpResponse.szResponse, false, sszErrors);
 					if (JsonSuccess(eJsonRet) && objResponseFailure.IsValid())
 					{
 						// Failure parses, probably auth error.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { AbxrBase, AbxrEvent, AbxrLog, AbxrStorage, AbxrTelemetry, AbxrAIProxy, 
 import { Partner } from "./AbxrLibClient";
 // Import XR dialog template
 import { getXRDialogTemplate, getXRDialogStyles, XRDialogConfig, XRVirtualKeyboard } from './templates/XRAuthDialog';
+// Import device detection utilities
+import { AbxrDetectAllDeviceInfo, AbxrDetectOsVersion, AbxrDetectDeviceModel, AbxrDetectIpAddress } from './utils/AbxrDeviceDetection';
 
 
 // Initialize all static members
@@ -332,12 +334,16 @@ export {
     AbxrStorage,
     AbxrTelemetry,
     AbxrAIProxy,
-    LogLevel,
-    Partner,
+    LogLevel as AbxrLogLevel,
+    Partner as AbxrPartner,
     InteractionType,
     EventStatus,
     hasApiVersion,
-    addApiVersion
+    addApiVersion,
+    AbxrDetectAllDeviceInfo,
+    AbxrDetectOsVersion,
+    AbxrDetectDeviceModel,
+    AbxrDetectIpAddress
 };
 
 // Types for authMechanism notification
@@ -1248,13 +1254,28 @@ if (typeof window !== 'undefined') {
         AbxrTelemetry,
         AbxrAIProxy,
         AbxrDictStrings,
-        LogLevel,
-        Partner,
+        AbxrLogLevel: LogLevel,
+        AbxrPartner: Partner,
         AbxrResult,
+        // Device detection utilities
+        AbxrDetectAllDeviceInfo,
+        AbxrDetectOsVersion,
+        AbxrDetectDeviceModel,
+        AbxrDetectIpAddress,
         Abxr
     };
     // Also expose the global function directly
     (window as any).Abxr_init = Abxr_init;
+    
+    // Expose device detection functions directly for easy testing
+    (window as any).AbxrDetectAllDeviceInfo = AbxrDetectAllDeviceInfo;
+    (window as any).AbxrDetectOsVersion = AbxrDetectOsVersion;
+    (window as any).AbxrDetectDeviceModel = AbxrDetectDeviceModel;
+    (window as any).AbxrDetectIpAddress = AbxrDetectIpAddress;
+    
+    // Expose prefixed versions of LogLevel and Partner
+    (window as any).AbxrLogLevel = LogLevel;
+    (window as any).AbxrPartner = Partner;
     console.log('AbxrLib: Loaded into global scope. Use Abxr for simple API or AbxrLib for advanced features.');
 }
 
@@ -1324,8 +1345,30 @@ export function Abxr_init(appId: string, orgId?: string, authSecret?: string, ap
             // Clear any previous auth errors before attempting authentication
             AbxrLibClient.clearLastAuthError();
             
-            // Attempt initial authentication
-            AbxrLibInit.Authenticate(appId, finalOrgId, deviceId, finalAuthSecret, Partner.eArborXR)
+            // Detect and set device information before authentication
+            console.log('AbxrLib: Detecting device information...');
+            AbxrDetectAllDeviceInfo()
+                .then((deviceInfo) => {
+                    console.log(`AbxrLib: Device detection complete - OS: ${deviceInfo.osVersion}, Browser: ${deviceInfo.deviceModel}, IP: ${deviceInfo.ipAddress}`);
+                    
+                    // Set the detected values in the authentication object
+                    AbxrLibInit.set_OsVersion(deviceInfo.osVersion);
+                    AbxrLibInit.set_DeviceModel(deviceInfo.deviceModel);
+                    AbxrLibInit.set_IpAddress(deviceInfo.ipAddress);
+                    
+                    // Now attempt initial authentication with device info set
+                    return AbxrLibInit.Authenticate(appId, finalOrgId, deviceId, finalAuthSecret, Partner.eArborXR);
+                })
+                .catch((error) => {
+                    console.warn('AbxrLib: Device detection failed, using defaults:', error);
+                    // Set fallback values if detection fails
+                    AbxrLibInit.set_OsVersion('Unknown OS');
+                    AbxrLibInit.set_DeviceModel('Unknown Browser');
+                    AbxrLibInit.set_IpAddress('NA');
+                    
+                    // Still attempt authentication even if device detection failed
+                    return AbxrLibInit.Authenticate(appId, finalOrgId, deviceId, finalAuthSecret, Partner.eArborXR);
+                })
                 .then(async (result: number) => {
                     if (result === 0) {
                         console.log('AbxrLib: Initial authentication successful');

--- a/src/network/utils/DataObjectBase.ts
+++ b/src/network/utils/DataObjectBase.ts
@@ -605,7 +605,7 @@ export function GenerateJsonList(l: DbSet<DataObjectBase>, eDumpCategory: DumpCa
 	return szJSON;
 }
 
-export function LoadFromJson(o: DataObjectBase | null, szJSON: string): JsonResult
+export function LoadFromJson(o: DataObjectBase | null, szJSON: string, bErrorOnOutOfBandData: boolean): JsonResult
 {
 	var objJsonObject:	any = null;
 
@@ -646,7 +646,7 @@ export function LoadFromJson(o: DataObjectBase | null, szJSON: string): JsonResu
 
 							if (objChild !== null)
 							{
-								LoadFromJson(objChild, szValue as string);
+								LoadFromJson(objChild, szValue as string, bErrorOnOutOfBandData);
 							}
 						}
 					}

--- a/src/network/utils/DotNetishTypes.ts
+++ b/src/network/utils/DotNetishTypes.ts
@@ -728,27 +728,45 @@ export class AbxrDictStrings extends Dictionary<string, string>
 		// ---
 		return this;
 	}
+	public override ToString(): string
+	{
+		var	szRet : string = "";
+
+		for (let entry of this.entries())
+		{
+			if (szRet.length > 0)
+			{
+				szRet += ',';
+			}
+			szRet += entry[0].escapeForSerialization();
+			szRet += '=';
+			szRet += entry[1].escapeForSerialization();
+		}
+		// ---
+		return szRet;
+	}
 	// ---
 	private CommaSeparatedStringToDictionary(szDict: string): void
 	{
-		var	vsz:		Array<string> = new Array<string>;
-		var	szKey:		string = "",
-			szValue:	string = "";
+		szDict.unescapeAndDeserializeKeyValue((key: string, value: string) => super.Add(key, value))
+		// var	vsz:		Array<string> = new Array<string>;
+		// var	szKey:		string = "",
+		// 	szValue:	string = "";
 
-		this.clear();
-		vsz = szDict.split(',');
-		for (let sz of vsz.values())
-		{
-			var	vszEquals: Array<string> = new Array<string>;
+		// this.clear();
+		// vsz = szDict.split(',');
+		// for (let sz of vsz.values())
+		// {
+		// 	var	vszEquals: Array<string> = new Array<string>;
 
-			vszEquals = sz.split('=');
-			if (vszEquals.length >= 1)
-			{
-				szKey = vszEquals[0].trim();
-				szValue = (vszEquals.length >= 2) ? vszEquals[1].trim() : "";
-				super.Add(szKey, szValue);
-			}
-		}
+		// 	vszEquals = sz.split('=');
+		// 	if (vszEquals.length >= 1)
+		// 	{
+		// 		szKey = vszEquals[0].trim();
+		// 		szValue = (vszEquals.length >= 2) ? vszEquals[1].trim() : "";
+		// 		super.Add(szKey, szValue);
+		// 	}
+		// }
 	}
 	private JsonFieldValueToDictionary(szJsonFieldValue: string): void
 	{
@@ -816,13 +834,13 @@ export class StringList extends Array<string>
 	{
 		var	szRet: string = "";
 
-		for (let sz of this.entries())
+		for (let [n, sz] of this.entries())
 		{
 			if (szRet.length > 0)
 			{
 				szRet += ',';
 			}
-			szRet += sz;
+			szRet += sz.escapeForSerialization();
 		}
 		// ---
 		return szRet;
@@ -830,19 +848,20 @@ export class StringList extends Array<string>
 	// ---
 	private CommaSeparatedStringToStringList(szStringList: string): void
 	{
-		var	vsz: Array<string>;
+		szStringList.unescapeAndDeserialize((value: string) => this.push(value))
+		// var	vsz: Array<string>;
 
-		// No doubt better way to do this.
-		while (this.length > 0)
-		{
-			this.pop();
-		}
-		vsz = szStringList.split(',');
-		// Probably better way to do this as well, something similar to this.push(vsz.values()) which is unkosher apparently.
-		for (let sz of vsz.values())
-		{
-			this.push(sz);
-		}
+		// // No doubt better way to do this.
+		// while (this.length > 0)
+		// {
+		// 	this.pop();
+		// }
+		// vsz = szStringList.split(',');
+		// // Probably better way to do this as well, something similar to this.push(vsz.values()) which is unkosher apparently.
+		// for (let sz of vsz.values())
+		// {
+		// 	this.push(sz);
+		// }
 	}
 };
 

--- a/src/network/utils/DotNetishTypes.ts
+++ b/src/network/utils/DotNetishTypes.ts
@@ -749,24 +749,6 @@ export class AbxrDictStrings extends Dictionary<string, string>
 	private CommaSeparatedStringToDictionary(szDict: string): void
 	{
 		szDict.unescapeAndDeserializeKeyValue((key: string, value: string) => super.Add(key, value))
-		// var	vsz:		Array<string> = new Array<string>;
-		// var	szKey:		string = "",
-		// 	szValue:	string = "";
-
-		// this.clear();
-		// vsz = szDict.split(',');
-		// for (let sz of vsz.values())
-		// {
-		// 	var	vszEquals: Array<string> = new Array<string>;
-
-		// 	vszEquals = sz.split('=');
-		// 	if (vszEquals.length >= 1)
-		// 	{
-		// 		szKey = vszEquals[0].trim();
-		// 		szValue = (vszEquals.length >= 2) ? vszEquals[1].trim() : "";
-		// 		super.Add(szKey, szValue);
-		// 	}
-		// }
 	}
 	private JsonFieldValueToDictionary(szJsonFieldValue: string): void
 	{
@@ -849,19 +831,6 @@ export class StringList extends Array<string>
 	private CommaSeparatedStringToStringList(szStringList: string): void
 	{
 		szStringList.unescapeAndDeserialize((value: string) => this.push(value))
-		// var	vsz: Array<string>;
-
-		// // No doubt better way to do this.
-		// while (this.length > 0)
-		// {
-		// 	this.pop();
-		// }
-		// vsz = szStringList.split(',');
-		// // Probably better way to do this as well, something similar to this.push(vsz.values()) which is unkosher apparently.
-		// for (let sz of vsz.values())
-		// {
-		// 	this.push(sz);
-		// }
 	}
 };
 

--- a/src/network/utils/DotNetishTypes.ts
+++ b/src/network/utils/DotNetishTypes.ts
@@ -4,6 +4,7 @@
 ///		Co-maintained with the one in AbxrInterop.cs.
 
 import { atol, DATEMAXVALUE, DATEMINVALUE, Regex } from "../types";
+import { escapeForSerialization } from "./StringUtils";
 
 /// <summary>
 /// Main return code for library operations.
@@ -738,9 +739,9 @@ export class AbxrDictStrings extends Dictionary<string, string>
 			{
 				szRet += ',';
 			}
-			szRet += entry[0].escapeForSerialization();
+			szRet += escapeForSerialization(entry[0]);
 			szRet += '=';
-			szRet += entry[1].escapeForSerialization();
+			szRet += escapeForSerialization(entry[1]);
 		}
 		// ---
 		return szRet;
@@ -822,7 +823,7 @@ export class StringList extends Array<string>
 			{
 				szRet += ',';
 			}
-			szRet += sz.escapeForSerialization();
+			szRet += escapeForSerialization(sz);
 		}
 		// ---
 		return szRet;

--- a/src/network/utils/DotNetishTypes.ts
+++ b/src/network/utils/DotNetishTypes.ts
@@ -173,6 +173,7 @@ export function EventStatusToString(eRet: EventStatus): string
 export enum JsonResult
 {
 	eOk,
+	eOutOfBandDataFound,
 	eBadJsonStructure,
 	eMissingField,
 	eExtraneousField,
@@ -203,7 +204,7 @@ export enum JsonResult
 
 export function JsonSuccess(eRet: JsonResult): boolean
 {
-	return (eRet === JsonResult.eOk);
+	return (eRet === JsonResult.eOk || eRet === JsonResult.eOutOfBandDataFound);
 }
 
 export function JsonResultToString(eRet: JsonResult): string

--- a/src/network/utils/StringUtils.ts
+++ b/src/network/utils/StringUtils.ts
@@ -1,0 +1,150 @@
+/**
+ * Extension method for escaping strings in StringList and AbxrDictStrings for serializing into comma-separated single string.
+ */
+export function escapeForSerialization(str: string): string {
+    const sOut: string[] = [];
+
+    for (const c of str) {
+        switch (c) {
+            case '\\':
+                sOut.push('\\\\');
+                break;
+            case '\"':
+                sOut.push('\\\"');
+                break;
+            case ',':
+                sOut.push(',');
+                break;
+            case '=':
+                sOut.push('=');
+                break;
+            default:
+                sOut.push(c);
+        }
+    }
+    
+    return sOut.join('');
+}
+
+// Alternative implementation using string extension (if you prefer extension-like syntax)
+declare global {
+    interface String {
+        escapeForSerialization(): string;
+    }
+}
+
+String.prototype.escapeForSerialization = function(): string {
+    return escapeForSerialization(this.toString());
+};
+
+/**
+ * Extension method for de-escaping strings into StringList from serialized comma-separated single string.
+ */
+export function unescapeAndDeserialize(str: string, pfnAddString: (value: string) => void): void {
+    const sOut: string[] = [];
+    let escapedState: boolean = false;
+
+    for (const c of str) {
+        switch (c) {
+            case '\\':
+                if (escapedState) {
+                    sOut.push(c);
+                    escapedState = false;
+                } else {
+                    escapedState = true;
+                }
+                break;
+            case ',':
+                if (escapedState) {
+                    sOut.push(c);
+                } else {
+                    pfnAddString(sOut.join(''));
+                    sOut.length = 0; // clear the array
+                }
+                escapedState = false;
+                break;
+            default:
+                sOut.push(c);
+                escapedState = false;
+        }
+    }
+    
+    if (sOut.length > 0) {
+        pfnAddString(sOut.join(''));
+    }
+}
+
+// Extension-like syntax for unescapeAndDeserialize
+declare global {
+    interface String {
+        escapeForSerialization(): string;
+        unescapeAndDeserialize(pfnAddString: (value: string) => void): void;
+    }
+}
+
+String.prototype.unescapeAndDeserialize = function(pfnAddString: (value: string) => void): void {
+    return unescapeAndDeserialize(this.toString(), pfnAddString);
+};
+
+/**
+ * Extension method for de-escaping strings into StringList from serialized comma-separated single string.
+ * Overloaded version that handles key-value pairs (first, second parameters).
+ */
+export function unescapeAndDeserializeKeyValue(str: string, pfnAddString: (first: string, second: string) => void): void {
+    const sFirst: string[] = [];
+    const sSecond: string[] = [];
+    let escapedState: boolean = false;
+    let onFirst: boolean = true;
+
+    for (const c of str) {
+        switch (c) {
+            case '\\':
+                if (escapedState) {
+                    if (onFirst) sFirst.push(c); else sSecond.push(c);
+                    escapedState = false;
+                } else {
+                    escapedState = true;
+                }
+                break;
+            case '=':
+                if (escapedState) {
+                    if (onFirst) sFirst.push(c); else sSecond.push(c);
+                } else {
+                    onFirst = false;
+                }
+                escapedState = false;
+                break;
+            case ',':
+                if (escapedState) {
+                    if (onFirst) sFirst.push(c); else sSecond.push(c);
+                } else {
+                    pfnAddString(sFirst.join(''), sSecond.join(''));
+                    sFirst.length = 0; // clear the array
+                    sSecond.length = 0; // clear the array
+                    onFirst = true;
+                }
+                escapedState = false;
+                break;
+            default:
+                if (onFirst) sFirst.push(c); else sSecond.push(c);
+                escapedState = false;
+        }
+    }
+    
+    if (sFirst.length > 0 && sSecond.length > 0 && !onFirst) {
+        pfnAddString(sFirst.join(''), sSecond.join(''));
+    }
+}
+
+// Extension-like syntax for unescapeAndDeserializeKeyValue
+declare global {
+    interface String {
+        escapeForSerialization(): string;
+        unescapeAndDeserialize(pfnAddString: (value: string) => void): void;
+        unescapeAndDeserializeKeyValue(pfnAddString: (first: string, second: string) => void): void;
+    }
+}
+
+String.prototype.unescapeAndDeserializeKeyValue = function(pfnAddString: (first: string, second: string) => void): void {
+    return unescapeAndDeserializeKeyValue(this.toString(), pfnAddString);
+};

--- a/src/network/utils/StringUtils.ts
+++ b/src/network/utils/StringUtils.ts
@@ -13,10 +13,10 @@ export function escapeForSerialization(str: string): string {
                 sOut.push('\\\"');
                 break;
             case ',':
-                sOut.push(',');
+                sOut.push('\\,');
                 break;
             case '=':
-                sOut.push('=');
+                sOut.push('\\=');
                 break;
             default:
                 sOut.push(c);

--- a/src/test.ts
+++ b/src/test.ts
@@ -252,6 +252,27 @@ async function TestEmptyDictMeta()
 	console.log(GenerateJson(abxrEvent, DumpCategory.eDumpingJsonForBackend), "\n");
 }
 
+function TestEscapingAndUnescaping()
+{
+	var dictStrings:	AbxrDictStrings = new AbxrDictStrings();
+	var dictStrings2:	AbxrDictStrings = new AbxrDictStrings();
+	var lszStrings:		StringList = new StringList();
+	var lszStrings2:	StringList = new StringList();
+	var szStringRep:	string = "";
+
+	dictStrings.Add("Utterly", "Prosaic");
+	dictStrings.Add("This has an embedded \"quote\" in it", "Embedded equals = problems if not \"handled\" correctly, not to mention commas and \\backslashes.");
+	szStringRep = dictStrings.ToString();
+	dictStrings2.FromCommaSeparatedList(szStringRep);
+	// ---
+	lszStrings.push("George");
+	lszStrings.push("Watch out for that \"tree\", Fella and Ursula stay in step.");
+	lszStrings.push("Ape call = doodleyabba.");
+	szStringRep = lszStrings.ToString();
+	lszStrings2.FromCommaSeparatedList(szStringRep);
+	szStringRep = "Debug trace placeholder";
+}
+
 async function TestJson(): Promise<void>
 {
 	var objTestData:	TestData = new TestData();
@@ -268,6 +289,7 @@ async function TestJson(): Promise<void>
 	try
 	{
 		// TestEmptyDictMeta();
+		// TestEscapingAndUnescaping();
 		// Sequential.
 		// await PrintStuffEveryThirdOfASecond();
 		// await PrintStuffEveryHalfOfASecond();

--- a/src/utils/AbxrDeviceDetection.ts
+++ b/src/utils/AbxrDeviceDetection.ts
@@ -1,0 +1,208 @@
+/**
+ * Device detection utilities for AbxrLib
+ * Provides functions to detect OS version, browser information, and IP address
+ */
+
+/**
+ * Detects the operating system and version from the user agent string
+ * @returns OS version string (e.g., "Windows 10", "macOS 14.0", "iOS 17.1")
+ */
+export function AbxrDetectOsVersion(): string {
+    if (typeof navigator === 'undefined') {
+        return 'Unknown OS';
+    }
+
+    const userAgent = navigator.userAgent;
+    
+    // Windows detection
+    if (userAgent.includes('Windows NT')) {
+        const windowsVersionMatch = userAgent.match(/Windows NT (\d+\.\d+)/);
+        if (windowsVersionMatch) {
+            const ntVersion = windowsVersionMatch[1];
+            // Map NT versions to Windows versions
+            const windowsVersionMap: { [key: string]: string } = {
+                '10.0': 'Windows 10/11',
+                '6.3': 'Windows 8.1',
+                '6.2': 'Windows 8',
+                '6.1': 'Windows 7',
+                '6.0': 'Windows Vista'
+            };
+            return windowsVersionMap[ntVersion] || `Windows NT ${ntVersion}`;
+        }
+        return 'Windows';
+    }
+    
+    // macOS detection
+    if (userAgent.includes('Mac OS X')) {
+        const macVersionMatch = userAgent.match(/Mac OS X (\d+[._]\d+([._]\d+)?)/);
+        if (macVersionMatch) {
+            const version = macVersionMatch[1].replace(/_/g, '.');
+            return `macOS ${version}`;
+        }
+        return 'macOS';
+    }
+    
+    // iOS detection
+    if (userAgent.includes('iPhone') || userAgent.includes('iPad')) {
+        const iosVersionMatch = userAgent.match(/OS (\d+[._]\d+([._]\d+)?)/);
+        if (iosVersionMatch) {
+            const version = iosVersionMatch[1].replace(/_/g, '.');
+            const device = userAgent.includes('iPhone') ? 'iPhone' : 'iPad';
+            return `iOS ${version} (${device})`;
+        }
+        return userAgent.includes('iPhone') ? 'iOS (iPhone)' : 'iOS (iPad)';
+    }
+    
+    // Android detection
+    if (userAgent.includes('Android')) {
+        const androidVersionMatch = userAgent.match(/Android (\d+(?:\.\d+)*)/);
+        if (androidVersionMatch) {
+            return `Android ${androidVersionMatch[1]}`;
+        }
+        return 'Android';
+    }
+    
+    // Linux detection
+    if (userAgent.includes('Linux')) {
+        return 'Linux';
+    }
+    
+    // Chrome OS detection
+    if (userAgent.includes('CrOS')) {
+        return 'Chrome OS';
+    }
+    
+    return 'Unknown OS';
+}
+
+/**
+ * Detects the browser name and version as device model
+ * @returns Browser information string (e.g., "Chrome 120.0.6099.109", "Firefox 121.0")
+ */
+export function AbxrDetectDeviceModel(): string {
+    if (typeof navigator === 'undefined') {
+        return 'Unknown Browser';
+    }
+
+    const userAgent = navigator.userAgent;
+    
+    // Chrome detection (must come before Safari since Chrome includes Safari in UA)
+    if (userAgent.includes('Chrome') && !userAgent.includes('Edg')) {
+        const chromeVersionMatch = userAgent.match(/Chrome\/(\d+(?:\.\d+)*)/);
+        if (chromeVersionMatch) {
+            return `Chrome ${chromeVersionMatch[1]}`;
+        }
+        return 'Chrome';
+    }
+    
+    // Edge detection
+    if (userAgent.includes('Edg')) {
+        const edgeVersionMatch = userAgent.match(/Edg\/(\d+(?:\.\d+)*)/);
+        if (edgeVersionMatch) {
+            return `Edge ${edgeVersionMatch[1]}`;
+        }
+        return 'Edge';
+    }
+    
+    // Firefox detection
+    if (userAgent.includes('Firefox')) {
+        const firefoxVersionMatch = userAgent.match(/Firefox\/(\d+(?:\.\d+)*)/);
+        if (firefoxVersionMatch) {
+            return `Firefox ${firefoxVersionMatch[1]}`;
+        }
+        return 'Firefox';
+    }
+    
+    // Safari detection
+    if (userAgent.includes('Safari') && !userAgent.includes('Chrome')) {
+        const safariVersionMatch = userAgent.match(/Version\/(\d+(?:\.\d+)*)/);
+        if (safariVersionMatch) {
+            return `Safari ${safariVersionMatch[1]}`;
+        }
+        return 'Safari';
+    }
+    
+    // Opera detection
+    if (userAgent.includes('OPR') || userAgent.includes('Opera')) {
+        const operaVersionMatch = userAgent.match(/(?:OPR|Opera)\/(\d+(?:\.\d+)*)/);
+        if (operaVersionMatch) {
+            return `Opera ${operaVersionMatch[1]}`;
+        }
+        return 'Opera';
+    }
+    
+    return 'Unknown Browser';
+}
+
+/**
+ * Attempts to get the client's IP address
+ * Note: Due to browser security restrictions, this may not always be possible
+ * @returns Promise that resolves to IP address string or 'NA'
+ */
+export async function AbxrDetectIpAddress(): Promise<string> {
+    try {
+        // Try multiple IP detection services as fallbacks
+        const services = [
+            'https://api.ipify.org?format=json',
+            'https://ipapi.co/json/',
+            'https://httpbin.org/ip'
+        ];
+        
+        for (const service of services) {
+            try {
+                const response = await fetch(service, {
+                    method: 'GET',
+                    headers: {
+                        'Accept': 'application/json'
+                    },
+                    // Add timeout to prevent hanging
+                    signal: AbortSignal.timeout(5000)
+                });
+                
+                if (response.ok) {
+                    const data = await response.json();
+                    
+                    // Different services return IP in different fields
+                    const ip = data.ip || data.query || data.origin;
+                    if (ip && typeof ip === 'string') {
+                        // Basic IP validation
+                        if (ip.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/) || 
+                            ip.match(/^[0-9a-fA-F:]+$/)) {
+                            return ip;
+                        }
+                    }
+                }
+            } catch (serviceError) {
+                // Continue to next service
+                continue;
+            }
+        }
+        
+        return 'NA';
+    } catch (error) {
+        console.warn('AbxrLib: Could not detect IP address:', error);
+        return 'NA';
+    }
+}
+
+/**
+ * Detects all device information at once
+ * @returns Promise that resolves to an object with osVersion, deviceModel, and ipAddress
+ */
+export async function AbxrDetectAllDeviceInfo(): Promise<{
+    osVersion: string;
+    deviceModel: string;
+    ipAddress: string;
+}> {
+    const [osVersion, deviceModel, ipAddress] = await Promise.all([
+        Promise.resolve(AbxrDetectOsVersion()),
+        Promise.resolve(AbxrDetectDeviceModel()),
+        AbxrDetectIpAddress()
+    ]);
+    
+    return {
+        osVersion,
+        deviceModel,
+        ipAddress
+    };
+}

--- a/testers/device-detection-test.html
+++ b/testers/device-detection-test.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Device Detection Test - AbxrLib</title>
+  <script src="dist/abxrlib-for-webxr.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+      background-color: #f5f5f5;
+    }
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      background: white;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    }
+    .info-box {
+      background: #f8f9fa;
+      border: 1px solid #dee2e6;
+      border-radius: 4px;
+      padding: 15px;
+      margin: 10px 0;
+    }
+    .detected-info {
+      background: #d4edda;
+      border-color: #c3e6cb;
+      color: #155724;
+    }
+    .error-info {
+      background: #f8d7da;
+      border-color: #f5c6cb;
+      color: #721c24;
+    }
+    .status {
+      font-weight: bold;
+      margin: 10px 0;
+    }
+    button {
+      background: #007bff;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+      margin: 5px;
+    }
+    button:hover {
+      background: #0056b3;
+    }
+    .log {
+      background: #f8f9fa;
+      border: 1px solid #dee2e6;
+      border-radius: 4px;
+      padding: 10px;
+      margin: 10px 0;
+      max-height: 300px;
+      overflow-y: auto;
+      font-family: monospace;
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>AbxrLib Device Detection Test</h1>
+    
+    <div class="info-box">
+      <h3>Test Purpose</h3>
+      <p>This test verifies that AbxrLib correctly detects and sets device information (OS version, browser/device model, and IP address) during authentication.</p>
+    </div>
+
+    <div class="status" id="status">Status: Initializing...</div>
+    
+    <div id="deviceInfo" class="info-box" style="display: none;">
+      <h3>Detected Device Information</h3>
+      <p><strong>OS Version:</strong> <span id="osVersion">-</span></p>
+      <p><strong>Device Model (Browser):</strong> <span id="deviceModel">-</span></p>
+      <p><strong>IP Address:</strong> <span id="ipAddress">-</span></p>
+    </div>
+
+    <div id="authInfo" class="info-box" style="display: none;">
+      <h3>Authentication Status</h3>
+      <p><strong>Authenticated:</strong> <span id="authStatus">-</span></p>
+      <p><strong>User ID:</strong> <span id="userId">-</span></p>
+      <p><strong>User Email:</strong> <span id="userEmail">-</span></p>
+    </div>
+
+    <div>
+      <button onclick="testDeviceDetection()">Test Device Detection Only</button>
+      <button onclick="testAuthentication()">Test Full Authentication</button>
+      <button onclick="clearLog()">Clear Log</button>
+    </div>
+
+    <div class="log" id="logOutput"></div>
+  </div>
+
+  <script>
+    let logOutput = document.getElementById('logOutput');
+    let originalConsoleLog = console.log;
+    let originalConsoleWarn = console.warn;
+    let originalConsoleError = console.error;
+
+    // Intercept console logs to display them on the page
+    function addToLog(message, type = 'log') {
+      const timestamp = new Date().toLocaleTimeString();
+      const logEntry = document.createElement('div');
+      logEntry.style.color = type === 'error' ? 'red' : type === 'warn' ? 'orange' : 'black';
+      logEntry.textContent = `[${timestamp}] ${message}`;
+      logOutput.appendChild(logEntry);
+      logOutput.scrollTop = logOutput.scrollHeight;
+    }
+
+    console.log = function(...args) {
+      originalConsoleLog.apply(console, args);
+      addToLog(args.join(' '), 'log');
+    };
+
+    console.warn = function(...args) {
+      originalConsoleWarn.apply(console, args);
+      addToLog(args.join(' '), 'warn');
+    };
+
+    console.error = function(...args) {
+      originalConsoleError.apply(console, args);
+      addToLog(args.join(' '), 'error');
+    };
+
+    // Test device detection without authentication
+    async function testDeviceDetection() {
+      document.getElementById('status').textContent = 'Status: Testing device detection...';
+      
+      try {
+        // Import the device detection functions directly
+        // Note: This assumes the functions are exported from the bundle
+        if (typeof AbxrDetectAllDeviceInfo !== 'undefined') {
+          const deviceInfo = await AbxrDetectAllDeviceInfo();
+          
+          document.getElementById('osVersion').textContent = deviceInfo.osVersion;
+          document.getElementById('deviceModel').textContent = deviceInfo.deviceModel;
+          document.getElementById('ipAddress').textContent = deviceInfo.ipAddress;
+          document.getElementById('deviceInfo').style.display = 'block';
+          document.getElementById('deviceInfo').className = 'info-box detected-info';
+          
+          document.getElementById('status').textContent = 'Status: Device detection completed successfully!';
+          console.log('Device detection test completed:', deviceInfo);
+        } else {
+          throw new Error('Device detection functions not available in bundle');
+        }
+      } catch (error) {
+        document.getElementById('status').textContent = 'Status: Device detection failed!';
+        document.getElementById('deviceInfo').style.display = 'block';
+        document.getElementById('deviceInfo').className = 'info-box error-info';
+        console.error('Device detection test failed:', error);
+      }
+    }
+
+    // Test full authentication with device detection
+    function testAuthentication() {
+      document.getElementById('status').textContent = 'Status: Testing authentication with device detection...';
+      
+      // Use test credentials (you may need to update these)
+      const testAppId = '06bdf0bf-a2d7-4dfa-9ef5-c551cfc9a7f9';
+      
+      // Initialize AbxrLib - this should trigger device detection
+      Abxr_init(testAppId);
+      
+      // Monitor authentication status
+      const checkInterval = setInterval(() => {
+        if (Abxr.isConfigured()) {
+          clearInterval(checkInterval);
+          
+          document.getElementById('status').textContent = 'Status: Authentication completed!';
+          document.getElementById('authStatus').textContent = 'Yes';
+          document.getElementById('userId').textContent = Abxr.getUserId() || 'Not available';
+          document.getElementById('userEmail').textContent = Abxr.getUserEmail() || 'Not available';
+          document.getElementById('authInfo').style.display = 'block';
+          document.getElementById('authInfo').className = 'info-box detected-info';
+          
+          console.log('Authentication test completed successfully');
+          
+          // Try to get the device info that was set during authentication
+          try {
+            const osVersion = AbxrLibInit.get_OsVersion();
+            const deviceModel = AbxrLibInit.get_DeviceModel();
+            const ipAddress = AbxrLibInit.get_IpAddress();
+            
+            document.getElementById('osVersion').textContent = osVersion || 'Not set';
+            document.getElementById('deviceModel').textContent = deviceModel || 'Not set';
+            document.getElementById('ipAddress').textContent = ipAddress || 'Not set';
+            document.getElementById('deviceInfo').style.display = 'block';
+            document.getElementById('deviceInfo').className = 'info-box detected-info';
+            
+            console.log('Device info from authentication:', { osVersion, deviceModel, ipAddress });
+          } catch (error) {
+            console.warn('Could not retrieve device info from AbxrLibInit:', error);
+          }
+          
+        } else if (Abxr.hasAuthenticationFailed()) {
+          clearInterval(checkInterval);
+          
+          document.getElementById('status').textContent = 'Status: Authentication failed!';
+          document.getElementById('authStatus').textContent = 'Failed';
+          document.getElementById('authInfo').style.display = 'block';
+          document.getElementById('authInfo').className = 'info-box error-info';
+          
+          console.error('Authentication test failed:', Abxr.getAuthenticationError());
+        }
+      }, 1000);
+      
+      // Timeout after 30 seconds
+      setTimeout(() => {
+        if (!Abxr.isConfigured() && !Abxr.hasAuthenticationFailed()) {
+          clearInterval(checkInterval);
+          document.getElementById('status').textContent = 'Status: Authentication timed out!';
+          console.error('Authentication test timed out');
+        }
+      }, 30000);
+    }
+
+    function clearLog() {
+      logOutput.innerHTML = '';
+    }
+
+    // Initialize page
+    document.getElementById('status').textContent = 'Status: Ready for testing';
+    console.log('Device Detection Test Page loaded');
+    console.log('User Agent:', navigator.userAgent);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
String escaping/unescaping for AbxrDictMeta and StringList when they get converted to/from single string.

Ported / fleshed out the "don't trust JSON structure from backend" code... which has to have / now does have IsValid() members for the items being parsed since "JSON didn't parse" can no longer be used as "it isn't that type of object" test.

Note this includes a squash merge of main ergo lots of extra diffs down there.