### PR TITLE
fix(auth): complete PIN auth chain and tighten error paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ When editing this repo, treat it as a standalone Web SDK: no references to Arbor
 
 ### Auth and endpoints
 
-- **Init:** Default path uses **app tokens**: `Abxr_init({ appToken, orgToken? })`. Legacy path: `Abxr_init({ appId, orgId?, authSecret? })` or deprecated positional args. orgToken can come from `abxr_org_token` URL param; that param is scrubbed from the URL on read (via `history.replaceState`) to prevent the JWT leaking through Referer/history/third-party scripts. The value is cached to a cookie for repeat visits.
+- **Init:** Default path uses **app tokens**: `Abxr_init({ appToken, orgToken? })`. Legacy path: `Abxr_init({ appId, orgId?, authSecret? })` or deprecated positional args. orgToken can come from `abxr_org_token` URL param; that param is scrubbed from the URL on read (via `history.replaceState`) to prevent the JWT leaking through Referer/history/third-party scripts. The value is cached to **`sessionStorage`** (per-tab, cleared on tab close) — not a cookie — because the orgToken is a short-lived JWT and a 30-day cookie would cause stale-token 401s. On init, any legacy `abxr_org_token` cookie is proactively deleted.
 - **Data:** Events, logs, and telemetry are batched and sent to the unified **`/v1/collect/data`** endpoint. Storage and other non-batched types use their per-type endpoints.
 - **AuthMechanism:** Callback receives normalized type (`"text"` | `"pin"` | `"email"`). Backend may send `assessmentPin` or `assessment_pin`; both normalize to `"pin"`.
 - **PIN Auto-Submit:** When orgToken JWT contains a `pin` claim, the SDK auto-submits it on the first assessmentPin auth attempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`abxr_org_token` is now stored in `sessionStorage` instead of a cookie.** The orgToken is a short-lived signed JWT; caching it in a 30-day cookie caused stale-token 401s on subsequent page loads without a fresh URL param. `sessionStorage` survives in-tab refresh but clears on tab close, which matches the LMS launch flow. On `Abxr_init` the SDK also deletes any legacy `abxr_org_token` cookie so existing users are healed automatically.
+
 ### Fixed
 
 - **PIN auto-submit now completes end-to-end.** Three connected bugs prevented the assessmentPin flow from succeeding:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **PIN auto-submit now completes end-to-end.** Three connected bugs prevented the assessmentPin flow from succeeding:
+  - `completeFinalAuth` was preserving the backend's original `prompt` (assessment label) and echoing it back; backend expects `prompt` replaced with the user's input.
+  - `formatAuthDataForSubmission` in 1.0.50 wrote PIN to a separate `pin` key; backend reuses the `prompt` key across all auth types.
+  - `AuthTokenRequest.m_dictAuthMechanism` lacked the `bfStringOnly` serialization flag, causing numeric-string PINs (e.g. `"995244"`) to be coerced to JSON numbers and rejected by the backend.
+- **Silent failures on invalid credentials.** Invalid `appToken` and missing `appId` paths in `Abxr_init` now fire `OnAuthCompleted(false, ..., errorMessage)` instead of returning silently.
+- **Empty email input** no longer builds a malformed `"@domain"` and bypasses the empty-input guard in `completeFinalAuth`.
+
+### Changed
+
+- **Removed `abxr_appid` URL parameter support.** `appId` is an app-embedded identifier and was never actually consumed from URL by `Abxr_init`. Callers passing `abxr_appid` via URL/cookie were already being ignored; the validation allowlist entry is now dropped.
+- **Routine informational logs in the auth flow** (device detection, initial auth success, auth complete, etc.) are now gated behind `Abxr.GetDebugMode()`. Errors and warnings remain always-on. Reduces console noise in production.
+
 ## [1.0.50] - 2026-04-20
 
 ### Added

--- a/src/Abxr.ts
+++ b/src/Abxr.ts
@@ -223,7 +223,6 @@ function AbxrValidateAndSanitizeParameter(name: string, value: string): string |
             break;
             
         case 'abxr_orgid':
-        case 'abxr_appid':
         case 'abxr_auth_secret':
             if (!AbxrIsValidAlphanumericId(value)) {
                 console.warn(`AbxrLib: Invalid format for ${name}: ${AbxrSanitizeForLog(value)}`);
@@ -3328,22 +3327,21 @@ export class Abxr {
         }
     }
     
-    // INTERNAL USE ONLY - Helper method to format auth data for completeFinalAuth based on type
-    // lib-backend expects auth_mechanism.prompt for type "text"; pin for assessmentPin; etc.
+    // INTERNAL USE ONLY - Helper method to format auth data for completeFinalAuth based on type.
+    // Backend reuses the `prompt` field across all auth types: on the initial response it carries
+    // the assessment label / instruction, on the final submission it carries the user's input.
     private static formatAuthDataForSubmission(inputValue: string, authType: string, domain?: string): any {
         const authData: any = {};
-
-        if (authType === 'email') {
-            const fullEmail = domain ? `${inputValue}@${domain}` : inputValue;
-            authData.prompt = fullEmail;
-        } else if (authType === 'assessmentPin' || authType === 'assessment_pin' || authType === 'pin') {
-            authData.pin = inputValue;
-        } else if (authType === 'text' || authType === 'custom') {
-            authData.prompt = inputValue;
-        } else {
-            authData.prompt = inputValue;
+        const trimmed = typeof inputValue === 'string' ? inputValue.trim() : '';
+        if (trimmed === '') {
+            authData.prompt = '';
+            return authData;
         }
-
+        if (authType === 'email') {
+            authData.prompt = domain ? `${trimmed}@${domain}` : trimmed;
+        } else {
+            authData.prompt = trimmed;
+        }
         return authData;
     }
     
@@ -3401,47 +3399,25 @@ export class Abxr {
         }
 
         try {
-            // Get the device ID that was used during initial authentication
-            const deviceId = AbxrGetOrCreateDeviceId();
-            
-            // Get the sessionId and app_id from the stored authentication object
-            const sessionId = AbxrLibInit.m_abxrLibAuthentication.m_szSessionId;
-            const appId = AbxrLibInit.m_abxrLibAuthentication.m_szAppID;
-            
-            // Get the existing authMechanism to preserve the type field
+            // Backend wants the response shape { type, <user-input-key>, domain? } — the
+            // original 'prompt' (assessment identifier) is NOT echoed back. Preserve type
+            // and domain (for email flows), drop everything else, layer user input on top.
             const authMechanism = AbxrLibInit.get_AuthMechanism();
-            
-            // Preserve original authMechanism metadata (type, domain, etc.)
             const originalType = authMechanism.get('type');
             const originalDomain = authMechanism.get('domain');
-            
-            // Clear existing data and rebuild with metadata preserved
             authMechanism.clear();
-            
-            // Re-add the type field first (required by server)  
-            if (originalType) {
-                authMechanism.Add('type', originalType);
-            }
-            
-            // Merge formatted user input (pin, email, or value) into authMechanism; backend expects type + domain + pin/email/etc.
+            if (originalType) authMechanism.Add('type', originalType);
             for (const [key, value] of Object.entries(authData)) {
                 authMechanism.Add(key, String(value));
             }
-            
-            // Re-add any additional metadata (like domain for email)
-            if (originalDomain) {
-                authMechanism.Add('domain', originalDomain);
-            }
-            
-            // Note: device_id, sessionId, app_id are already at the top level of the request
-            // They should NOT be duplicated inside authMechanism per API specification
-            
+            if (originalDomain) authMechanism.Add('domain', originalDomain);
+
             AbxrLibInit.set_AuthMechanism(authMechanism);
-            
+
             // Perform final authentication
             const result = await AbxrLibInit.FinalAuthenticate();
             if (result === 0) {
-                console.log('AbxrLib: Final authentication successful - library ready');
+                if (this.enableDebug) console.log('AbxrLib: Final authentication successful - library ready');
                 
                 // Extract module targets from auth response data (similar to Unity version)
                 const authResponseData = AbxrLibClient.getAuthResponseData();
@@ -4361,7 +4337,9 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
 
     if (useAppTokens) {
         if (!AbxrIsValidJwt(options.appToken!)) {
-            console.error('AbxrLib: appToken is not a valid JWT (expected 3 dot-separated segments)');
+            const errorMessage = 'appToken is not a valid JWT (expected 3 dot-separated segments)';
+            console.error(`AbxrLib: ${errorMessage}`);
+            Abxr.NotifyAuthCompleted(false, false, undefined, errorMessage);
             return;
         }
         if (options.appId || options.orgId || options.authSecret) {
@@ -4369,7 +4347,9 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
         }
     } else {
         if (!options.appId) {
-            console.error('AbxrLib: appId is required for initialization (legacy mode) or provide appToken for token mode');
+            const errorMessage = 'appId is required for initialization (legacy mode) or provide appToken for token mode';
+            console.error(`AbxrLib: ${errorMessage}`);
+            Abxr.NotifyAuthCompleted(false, false, undefined, errorMessage);
             return;
         }
     }
@@ -4413,7 +4393,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
         // Extract assessment PIN from orgToken JWT (if present)
         (Abxr as any).storedAssessmentPin = (Abxr as any).extractPinFromOrgToken(orgToken);
         Abxr.setPinAutoSubmitAttempted(false);
-        if (Abxr.getStoredAssessmentPin()) {
+        if (Abxr.getStoredAssessmentPin() && Abxr.GetDebugMode()) {
             console.log('AbxrLib: Assessment PIN found in orgToken JWT');
         }
 
@@ -4431,7 +4411,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
 
             AbxrLibClient.clearLastAuthError();
 
-            console.log('AbxrLib: Detecting device information...');
+            if (Abxr.GetDebugMode()) console.log('AbxrLib: Detecting device information...');
             AbxrDetectAllDeviceInfo(false)
                 .then((deviceInfo) => {
                     AbxrLibInit.set_OsVersion(deviceInfo.osVersion);
@@ -4454,7 +4434,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
                 })
                 .then(async (result: number) => {
                     if (result === 0) {
-                        console.log('AbxrLib: Initial authentication successful');
+                        if (Abxr.GetDebugMode()) console.log('AbxrLib: Initial authentication successful');
 
                         const authMechanism = AbxrLibInit.get_AuthMechanism();
                         const hasAuthMechanism = authMechanism && (
@@ -4472,15 +4452,12 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
                                 // PIN auto-submit: if we have a PIN from orgToken JWT and backend wants a PIN
                                 if (normalizedType === 'pin' && Abxr.getStoredAssessmentPin() && !Abxr.getPinAutoSubmitAttempted()) {
                                     Abxr.setPinAutoSubmitAttempted(true);
-                                    console.log('AbxrLib: Auto-submitting assessment PIN from orgToken JWT');
-                                    const pinData = { pin: Abxr.getStoredAssessmentPin()! };
+                                    if (Abxr.GetDebugMode()) console.log('AbxrLib: Auto-submitting assessment PIN from orgToken JWT');
+                                    const pinData = (Abxr as any).formatAuthDataForSubmission(Abxr.getStoredAssessmentPin()!, authData.type, authData.domain);
                                     const success = await (Abxr as any).completeFinalAuth(pinData);
-                                    if (success) {
-                                        // PIN auto-submit succeeded — auth complete, no dialog needed
-                                        // NotifyAuthCompleted(true) is called inside completeFinalAuth
-                                    } else {
+                                    if (!success) {
                                         // PIN auto-submit failed — fall through to show dialog
-                                        console.log('AbxrLib: PIN auto-submit failed, showing dialog for manual entry');
+                                        console.warn('AbxrLib: PIN auto-submit failed, showing dialog for manual entry');
                                         const callback = Abxr.getAuthMechanismCallback();
                                         if (callback && typeof callback === 'function') {
                                             try {
@@ -4492,7 +4469,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
                                     }
                                 } else {
                                     // No auto-submit — show dialog as normal
-                                    console.log(`AbxrLib: Additional authentication required - ${forCallback.type}${authData.domain ? ` (domain: ${authData.domain})` : ''}`);
+                                    if (Abxr.GetDebugMode()) console.log(`AbxrLib: Additional authentication required - ${forCallback.type}${authData.domain ? ` (domain: ${authData.domain})` : ''}`);
                                     const callback = Abxr.getAuthMechanismCallback();
                                     if (callback && typeof callback === 'function') {
                                         try {
@@ -4504,7 +4481,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
                                 }
                             }
                         } else {
-                            console.log('AbxrLib: Authentication complete - library ready');
+                            if (Abxr.GetDebugMode()) console.log('AbxrLib: Authentication complete - library ready');
                             const authResponseData = AbxrLibClient.getAuthResponseData();
                             const moduleTargets = Abxr.ExtractModuleTargets(authResponseData?.modules || []);
                             Abxr.NotifyAuthCompleted(true, false, moduleTargets);
@@ -4550,7 +4527,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
 
                 AbxrLibClient.clearLastAuthError();
 
-                console.log('AbxrLib: Detecting device information...');
+                if (Abxr.GetDebugMode()) console.log('AbxrLib: Detecting device information...');
                 AbxrDetectAllDeviceInfo(false)
                     .then((deviceInfo) => {
                         AbxrLibInit.set_OsVersion(deviceInfo.osVersion);
@@ -4573,7 +4550,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
                     })
                     .then(async (result: number) => {
                         if (result === 0) {
-                            console.log('AbxrLib: Initial authentication successful');
+                            if (Abxr.GetDebugMode()) console.log('AbxrLib: Initial authentication successful');
 
                             const authMechanism = AbxrLibInit.get_AuthMechanism();
                             const hasAuthMechanism = authMechanism && (
@@ -4587,7 +4564,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
                                 if (authData) {
                                     const normalizedType = Abxr.normalizeAuthMechanismTypeForInput(authData.type) || 'text';
                                     const forCallback = { ...authData, type: normalizedType };
-                                    console.log(`AbxrLib: Additional authentication required - ${forCallback.type}${authData.domain ? ` (domain: ${authData.domain})` : ''}`);
+                                    if (Abxr.GetDebugMode()) console.log(`AbxrLib: Additional authentication required - ${forCallback.type}${authData.domain ? ` (domain: ${authData.domain})` : ''}`);
                                     const callback = Abxr.getAuthMechanismCallback();
                                     if (callback && typeof callback === 'function') {
                                         try {
@@ -4596,13 +4573,13 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
                                             console.error('AbxrLib: Error in authMechanism callback:', error);
                                         }
                                     } else if (!callback) {
-                                        console.log('AbxrLib: No callback configured for additional authentication');
+                                        console.warn('AbxrLib: No callback configured for additional authentication');
                                     }
-                                } else {
+                                } else if (Abxr.GetDebugMode()) {
                                     console.log('AbxrLib: Additional authentication required (authMechanism detected)');
                                 }
                             } else {
-                                console.log('AbxrLib: Authentication complete - library ready');
+                                if (Abxr.GetDebugMode()) console.log('AbxrLib: Authentication complete - library ready');
                                 const authResponseData = AbxrLibClient.getAuthResponseData();
                                 const moduleTargets = Abxr.ExtractModuleTargets(authResponseData?.modules || []);
                                 Abxr.NotifyAuthCompleted(true, false, moduleTargets);
@@ -4612,7 +4589,7 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
                             const errorMessage = detailedError || `Authentication failed with code ${result}`;
 
                             if (AbxrShouldTryVersionFallback(errorMessage)) {
-                                console.log('AbxrLib: Attempting version fallback...');
+                                if (Abxr.GetDebugMode()) console.log('AbxrLib: Attempting version fallback...');
                                 const fallbackSuccess = await Abxr.attemptVersionFallback();
                                 if (!fallbackSuccess) {
                                     console.error('AbxrLib: Authentication failed:', errorMessage);

--- a/src/Abxr.ts
+++ b/src/Abxr.ts
@@ -98,13 +98,29 @@ function AbxrStripUrlParameter(name: string): void {
 // Cookie utility functions
 function AbxrSetCookie(name: string, value: string, days: number = 30): void {
     if (typeof document === 'undefined') return;
-    
+
     const expires = new Date();
     expires.setTime(expires.getTime() + (days * 24 * 60 * 60 * 1000));
     const expiresStr = expires.toUTCString();
-    
+
     // No URL encoding needed for our simple configuration values
     document.cookie = `${name}=${value}; expires=${expiresStr}; path=/; SameSite=Lax`;
+}
+
+function AbxrDeleteCookie(name: string): void {
+    if (typeof document === 'undefined') return;
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax`;
+}
+
+// sessionStorage is used for short-lived secrets like abxr_org_token that must
+// survive page refresh within a tab but must NOT persist across tabs or days.
+// Unlike cookies, sessionStorage is per-tab, auto-expires on tab close, and is
+// not sent on any network request.
+function AbxrSetSessionStorage(name: string, value: string): void {
+    try { window.sessionStorage?.setItem(name, value); } catch { /* quota/private mode */ }
+}
+function AbxrGetSessionStorage(name: string): string | null {
+    try { return window.sessionStorage?.getItem(name) ?? null; } catch { return null; }
 }
 
 function AbxrGetCookie(name: string): string | null {
@@ -279,34 +295,44 @@ function AbxrGetRestUrlWithFallback(fallback?: string): string {
     return restUrl || fallback || 'https://lib-backend.xrdm.app/v1/';
 }
 
-// Utility function to get abxr parameter with priority: GET params -> cookies -> fallback
+// Utility function to get abxr parameter with priority: GET params -> persistent store -> fallback.
+// For abxr_org_token (short-lived JWT), the persistent store is sessionStorage — scoped to the
+// tab, cleared on tab close, so stale tokens can't leak into a fresh navigation.
+// For longer-lived config (abxr_rest_url, abxr_orgid, abxr_auth_secret), the store is a cookie.
 function AbxrGetParameter(name: string, fallback?: string): string | undefined {
+    const useSessionStorage = name === 'abxr_org_token';
+
     // Priority 1: GET parameters
     const urlParam = AbxrGetUrlParameter(name);
     if (urlParam) {
-        // Scrub sensitive params from the URL on read. The token is a JWT
-        // carrying an assessment PIN claim; leaving it in the URL exposes
-        // it via Referer headers and browser history.
-        if (name === 'abxr_org_token') {
+        if (useSessionStorage) {
+            // Remove the JWT from the URL immediately to prevent leakage via
+            // Referer headers, browser history, or third-party scripts.
             AbxrStripUrlParameter(name);
         }
         const sanitizedParam = AbxrValidateAndSanitizeParameter(name, urlParam);
         if (sanitizedParam) {
-            // Save to cookie for future use
-            AbxrSetCookie(name, sanitizedParam);
+            if (useSessionStorage) {
+                // Cache to sessionStorage for page refreshes within this tab.
+                AbxrSetSessionStorage(name, sanitizedParam);
+                // Defensively clear any legacy cookie left over from prior SDK versions.
+                AbxrDeleteCookie(name);
+            } else {
+                AbxrSetCookie(name, sanitizedParam);
+            }
             return sanitizedParam;
         }
     }
-    
-    // Priority 2: Cookies
-    const cookieParam = AbxrGetCookie(name);
-    if (cookieParam) {
-        const sanitizedParam = AbxrValidateAndSanitizeParameter(name, cookieParam);
+
+    // Priority 2: persistent store
+    const storedParam = useSessionStorage ? AbxrGetSessionStorage(name) : AbxrGetCookie(name);
+    if (storedParam) {
+        const sanitizedParam = AbxrValidateAndSanitizeParameter(name, storedParam);
         if (sanitizedParam) {
             return sanitizedParam;
         }
     }
-    
+
     // Priority 3: Fallback value
     return fallback;
 }
@@ -4334,6 +4360,12 @@ export function Abxr_init(optionsOrAppId: AbxrInitOptions | string, orgId?: stri
 
     // Mode detection
     const useAppTokens = !!options.appToken;
+
+    // Defensively clear any legacy abxr_org_token cookie left over from SDK
+    // versions that persisted the JWT for 30 days. Short-lived tokens now live
+    // in sessionStorage instead; keeping the old cookie around would produce
+    // stale-token 401s on subsequent page loads.
+    AbxrDeleteCookie('abxr_org_token');
 
     if (useAppTokens) {
         if (!AbxrIsValidJwt(options.appToken!)) {

--- a/src/AbxrLibClient.ts
+++ b/src/AbxrLibClient.ts
@@ -89,7 +89,7 @@ export class AuthTokenRequest extends DataObjectBase
 	 	{m_szUserId: new FieldProperties("userId")},
 	 	{m_lszTags: new FieldProperties("tags")},
 	 	{m_dictGeoLocation: new FieldProperties("geolocation")},
-	 	{m_dictAuthMechanism: new FieldProperties("authMechanism")}));
+	 	{m_dictAuthMechanism: new FieldProperties("authMechanism", FieldPropertyFlags.bfStringOnly)}));
 	// ---
 	public GetMapProperties(): FieldPropertiesRecordContainer // virtual
 	{


### PR DESCRIPTION
## Summary

Completes the LMS PIN authentication flow and tightens error paths in both auth modes after an end-to-end audit of the auth chain. Discovered when a customer integration hit an authentication dialog instead of silently auto-submitting the PIN.

### Root cause

Three connected bugs prevented PIN auto-submit from succeeding against the real backend:

1. `completeFinalAuth` was echoing the backend's original `prompt` (assessment label) back on the final submission. Backend expects `prompt` to be *replaced* with the user's input.
2. `formatAuthDataForSubmission` (changed in 1.0.50) wrote the PIN value into a separate `pin` key. Backend reuses the `prompt` key across all auth types (pin, text, custom, email).
3. `AuthTokenRequest.m_dictAuthMechanism` lacked the `bfStringOnly` serialization flag. Without it, `AbxrDictStrings.GenerateJson()` coerced numeric-string PINs (e.g. `"995244"`) into JSON numbers via `StringIfNotNumber`, which the backend rejected.

Each individually was enough to break the flow. Diagnosed with instrumented logging that traced the full init → auth → response → auto-submit → FinalAuthenticate path, comparing SDK output against backend-captured request bodies.

### Fixes in this PR

- **`completeFinalAuth`** — preserves only `type` and `domain` from the backend's authMechanism; drops `prompt`; layers user input on top.
- **`formatAuthDataForSubmission`** — all auth types write user input to the `prompt` key. Email additionally appends `@domain`. Trims and short-circuits empty input so the existing guard in `completeFinalAuth` catches it.
- **`AuthTokenRequest.m_dictAuthMechanism`** — add `FieldPropertyFlags.bfStringOnly` so dict serialization uses native `JSON.stringify` instead of `GenerateJson`. Matches the pattern already used for `osVersion`, `xrdmVersion`, `appVersion`, and the sibling `AuthTokenRequest` in `AbxrLibCoreModel.ts`.

### Related cleanup from the audit

- **Invalid `appToken`** path now fires `OnAuthCompleted(false, ..., errorMessage)` instead of returning silently.
- **Missing `appId`** path gets the same symmetric treatment.
- **Removed `abxr_appid` URL parameter support.** `appId` is app-embedded; `Abxr_init` never actually consumed it from URL. Validation allowlist entry dropped.
- **Empty email input** no longer builds a malformed `"@domain"` value and bypasses the guard.
- **Dead locals and stranded comment** in `completeFinalAuth` removed.
- **Routine auth-flow INFO logs** gated behind `Abxr.GetDebugMode()` for production quietness. Errors and warnings remain always-on.
